### PR TITLE
Return an error when a tensor's name in gguf is long

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -18639,14 +18639,12 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
                 info->ne[j] = 1;
             }
 
-            ok = ok && gguf_fread_str(file, &info->name,                          &offset);
             if (strlen(info->name.data) > GGML_MAX_NAME - 1) {
                 fprintf(stderr, "%s: tensor name '%s' is too long (maximum length: %d characters)\n", __func__, info->name.data, GGML_MAX_NAME - 1);
-                fclose(file);
-                gguf_free(ctx);
-                return NULL;
+                ok = false;
             }
             
+            ok = ok && gguf_fread_str(file, &info->name,                          &offset);
             ok = ok && gguf_fread_el (file, &info->n_dims, sizeof(info->n_dims),  &offset);
             for (uint32_t j = 0; j < info->n_dims; ++j) {
                 ok = ok && gguf_fread_el(file, &info->ne[j], sizeof(info->ne[j]), &offset);

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -18640,6 +18640,13 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
             }
 
             ok = ok && gguf_fread_str(file, &info->name,                          &offset);
+            if (strlen(info->name.data) > GGML_MAX_NAME - 1) {
+                fprintf(stderr, "%s: tensor name '%s' is too long (maximum length: %d characters)\n", __func__, info->name.data, GGML_MAX_NAME - 1);
+                fclose(file);
+                gguf_free(ctx);
+                return NULL;
+            }
+            
             ok = ok && gguf_fread_el (file, &info->n_dims, sizeof(info->n_dims),  &offset);
             for (uint32_t j = 0; j < info->n_dims; ++j) {
                 ok = ok && gguf_fread_el(file, &info->ne[j], sizeof(info->ne[j]), &offset);


### PR DESCRIPTION
### Description
When writing a GGUF file, there are very few checks that are made but that could cause an error when loading and working with it. One of them is having tensor names that are longer than 64 characters. 

The name of a tensor when reading tensor information doesn't have a limit of characters on it as we can see here [`gguf_tensor_info`](https://github.com/ggerganov/ggml/blob/6b846cbde81ae02cd3e363311180ae706091933e/src/ggml.c#L18434-L18435) but when later on we work with the [GGML tensors](https://github.com/ggerganov/ggml/blob/6b846cbde81ae02cd3e363311180ae706091933e/include/ggml/ggml.h#L533) we find that there is indeed a limit which can cause an issue when [looking up a tensor by its name](https://github.com/ggerganov/ggml/blob/6b846cbde81ae02cd3e363311180ae706091933e/src/ggml.c#L3118).

### Changes Made
This PR concerns [`gguf_init_from_file`](https://github.com/ggerganov/ggml/blob/6b846cbde81ae02cd3e363311180ae706091933e/src/ggml.c#L18501).
