### PR TITLE
backend: remove duplicate backend typedefs

### DIFF
--- a/include/ggml/ggml-backend.h
+++ b/include/ggml/ggml-backend.h
@@ -7,10 +7,7 @@
 extern "C" {
 #endif
 
-    typedef struct ggml_backend_buffer_type * ggml_backend_buffer_type_t;
-    typedef struct ggml_backend_buffer * ggml_backend_buffer_t;
     typedef struct ggml_backend_event * ggml_backend_event_t;
-    typedef struct ggml_backend * ggml_backend_t;
     typedef void * ggml_backend_graph_plan_t;
 
     //


### PR DESCRIPTION
This commit removes the duplicate typedefs for backend structs in `ggml-backend.h`. These typedefs are already defined in `ggml-alloc.h` which `ggml-backend.h` includes.

There might be a case for having the typedefs in `ggml-backend.h` but if this perhaps is an oversight I think it might better to remove them from `ggml-backend.h` to avoid confusion.