### PR TITLE
cpu: Shift score for SSE4.2

### DIFF
--- a/src/ggml-cpu/cpu-feats-x86.cpp
+++ b/src/ggml-cpu/cpu-feats-x86.cpp
@@ -266,6 +266,10 @@ static int ggml_backend_cpu_x86_score() {
     int score = 0;
     cpuid_x86 is;
 
+#ifdef GGML_SSE42
+    if (!is.SSE42()) { return 0; }
+    score += 1<<2;
+#endif
 #ifdef GGML_FMA
     if (!is.FMA()) { return 0; }
     score += 1;
@@ -273,10 +277,6 @@ static int ggml_backend_cpu_x86_score() {
 #ifdef GGML_F16C
     if (!is.F16C()) { return 0; }
     score += 1<<1;
-#endif
-#ifdef GGML_SSE42
-    if (!is.SSE42()) { return 0; }
-    score += 1<<2;
 #endif
 #ifdef GGML_AVX
     if (!is.AVX()) { return 0; }


### PR DESCRIPTION
It seems that SSE4.2 first appeared in Nehalem, and FMA/F16C in Ivy Bridge. This precedence would also match that given by the microarchitectural levels agreed to by Intel and AMD:

   https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels