### PR TITLE
Skip metal backend tests for fp16 add/sub/mul/div operations (which don't have metal implementations)

### DIFF
--- a/src/ggml-metal/ggml-metal.m
+++ b/src/ggml-metal/ggml-metal.m
@@ -1204,17 +1204,18 @@ static bool ggml_metal_supports_op(const struct ggml_backend_metal_device_contex
                 default:
                     return false;
             }
+        case GGML_OP_ADD:
+        case GGML_OP_SUB:
+        case GGML_OP_MUL:
+        case GGML_OP_DIV:
+            return op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_NONE:
         case GGML_OP_RESHAPE:
         case GGML_OP_VIEW:
         case GGML_OP_TRANSPOSE:
         case GGML_OP_PERMUTE:
         case GGML_OP_CONCAT:
-        case GGML_OP_ADD:
-        case GGML_OP_SUB:
         case GGML_OP_ACC:
-        case GGML_OP_MUL:
-        case GGML_OP_DIV:
         case GGML_OP_REPEAT:
         case GGML_OP_SCALE:
         case GGML_OP_CLAMP:


### PR DESCRIPTION
Fix for broken CI on Metal backends after merging https://github.com/ggml-org/ggml/pull/1121