### PR TITLE
pkg-config: Use CMake install paths for lib, include

### DIFF
--- a/ggml.pc.in
+++ b/ggml.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${prefix}/lib
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: ggml
 Description: The GGML Tensor Library for Machine Learning


### PR DESCRIPTION
In case these are overridden.

Also:

```pkg-config
Cflags: -I${includedir}/ggml
```

The headers are currently installed to `${includedir}` not `${includedir}/ggml`, should this be changed? Or is this a typical pattern for pkg-config files?