### PR TITLE
Update example readme/shell output for gpt-2-backend

### DIFF
--- a/examples/gpt-2/README.md
+++ b/examples/gpt-2/README.md
@@ -134,7 +134,7 @@ models/gpt-2-117M/ggml-model.bin         100%[===============================>] 
 Done! Model '117M' saved in 'models/gpt-2-117M/ggml-model.bin'
 You can now use it like this:
 
-  $ ./bin/gpt-2 -m models/gpt-2-117M/ggml-model.bin -p "This is an example"
+  $ ./bin/gpt-2-backend -m models/gpt-2-117M/ggml-model.bin -p "This is an example"
 
 ```
 

--- a/examples/gpt-2/download-ggml-model.sh
+++ b/examples/gpt-2/download-ggml-model.sh
@@ -65,5 +65,5 @@ fi
 
 printf "Done! Model '$model' saved in 'models/gpt-2-$model/ggml-model.bin'\n"
 printf "You can now use it like this:\n\n"
-printf "  $ ./bin/gpt-2 -m models/gpt-2-$model/ggml-model.bin -p \"This is an example\"\n"
+printf "  $ ./bin/gpt-2-backend -m models/gpt-2-$model/ggml-model.bin -p \"This is an example\"\n"
 printf "\n"


### PR DESCRIPTION
Currently when you run through the example steps, the printed logs are recommending a bin target that doesn't exist. Updating to the correct reference.