### PR TITLE
ggml-cpu : rm unused variable

### DIFF
--- a/src/ggml-cpu/ggml-cpu.c
+++ b/src/ggml-cpu/ggml-cpu.c
@@ -4372,7 +4372,6 @@ static void ggml_compute_forward_add(
         struct ggml_tensor * dst) {
 
     const struct ggml_tensor * src0 = dst->src[0];
-    const struct ggml_tensor * src1 = dst->src[1];
 
     switch (src0->type) {
         case GGML_TYPE_F32:


### PR DESCRIPTION
Remove unused `src1` in `ggml_compute_forward_add` which throw a warning on compilation

```
src/ggml-cpu/ggml-cpu.c:4375:32: warning: unused variable 'src1' [-Wunused-variable]
 4375 |     const struct ggml_tensor * src1 = dst->src[1];
```