### PR TITLE
cpu: fix compile errors on arm+msvc (windows) for pointer casts

### DIFF
--- a/src/ggml-cpu/simd-mappings.h
+++ b/src/ggml-cpu/simd-mappings.h
@@ -71,7 +71,11 @@
     #define GGML_F16x8              float16x8_t
     #define GGML_F16x8_ZERO         vdupq_n_f16(0.0f)
     #define GGML_F16x8_SET1(x)      vdupq_n_f16(x)
-    #define GGML_F16x8_LOAD(x)      vld1q_f16((const ggml_fp16_internal_t *)(x))
+    #ifdef __cplusplus
+        #define GGML_F16x8_LOAD(x)      vld1q_f16(reinterpret_cast<const __fp16 *>(x))
+    #else
+        #define GGML_F16x8_LOAD(x)      vld1q_f16((const __fp16 *)(x))
+    #endif
     #define GGML_F16x8_STORE        vst1q_f16
     #define GGML_F16x8_FMA(a, b, c) vfmaq_f16(a, b, c)
     #define GGML_F16x8_ADD          vaddq_f16
@@ -99,7 +103,11 @@
     #define GGML_F16_VEC_ZERO           GGML_F16x8_ZERO
     #define GGML_F16_VEC_SET1           GGML_F16x8_SET1
     #define GGML_F16_VEC_LOAD(p, i)     GGML_F16x8_LOAD(p)
-    #define GGML_F16_VEC_STORE(p, r, i) GGML_F16x8_STORE((ggml_fp16_internal_t *)(p), (r)[i])
+    #ifdef __cplusplus
+        #define GGML_F16_VEC_STORE(p, r, i) GGML_F16x8_STORE(reinterpret_cast<__fp16 *>(p), (r)[i])
+    #else
+        #define GGML_F16_VEC_STORE(p, r, i) GGML_F16x8_STORE((__fp16 *)(p), (r)[i])
+    #endif
     #define GGML_F16_VEC_FMA            GGML_F16x8_FMA
     #define GGML_F16_VEC_ADD            GGML_F16x8_ADD
     #define GGML_F16_VEC_MUL            GGML_F16x8_MUL
@@ -114,7 +122,11 @@
     #define GGML_F32Cx4              float32x4_t
     #define GGML_F32Cx4_ZERO         vdupq_n_f32(0.0f)
     #define GGML_F32Cx4_SET1(x)      vdupq_n_f32(x)
-    #define GGML_F32Cx4_LOAD(x)      vcvt_f32_f16(vld1_f16((const ggml_fp16_internal_t *)(x)))
+    #ifdef __cplusplus
+        #define GGML_F32Cx4_LOAD(x)      vcvt_f32_f16(vld1_f16(reinterpret_cast<const __fp16 *>(x)))
+    #else
+        #define GGML_F32Cx4_LOAD(x)      vcvt_f32_f16(vld1_f16((const __fp16 *)(x)))
+    #endif
     #define GGML_F32Cx4_STORE(x, y)  vst1_f16(x, vcvt_f16_f32(y))
     #define GGML_F32Cx4_FMA(a, b, c) vfmaq_f32(a, b, c)
     #define GGML_F32Cx4_ADD          vaddq_f32
@@ -125,7 +137,11 @@
     #define GGML_F16_VEC_ZERO           GGML_F32Cx4_ZERO
     #define GGML_F16_VEC_SET1           GGML_F32Cx4_SET1
     #define GGML_F16_VEC_LOAD(p, i)     GGML_F32Cx4_LOAD(p)
-    #define GGML_F16_VEC_STORE(p, r, i) GGML_F32Cx4_STORE((ggml_fp16_internal_t *)(p), r[i])
+    #ifdef __cplusplus
+        #define GGML_F16_VEC_STORE(p, r, i) GGML_F32Cx4_STORE(reinterpret_cast<__fp16 *>(p), r[i])
+    #else
+        #define GGML_F16_VEC_STORE(p, r, i) GGML_F32Cx4_STORE((__fp16 *)(p), r[i])
+    #endif
     #define GGML_F16_VEC_FMA            GGML_F32Cx4_FMA
     #define GGML_F16_VEC_ADD            GGML_F32Cx4_ADD
     #define GGML_F16_VEC_MUL            GGML_F32Cx4_MUL


### PR DESCRIPTION
This PR attempts to fix the CI build failure in https://github.com/ggml-org/llama.cpp/pull/12732

The underlying arm functions actually expect `__fp16 *`, so this PR attempts to only match the expected function signature. E.g. ARM reference doc for [vld1q_f16()](https://developer.arm.com/documentation/dui0472/m/Using-NEON-Support/NEON-intrinsics-for-loading-a-single-vector-or-lane) and [vst1_f16()](https://developer.arm.com/documentation/dui0348/c/BABDCGGF).

It does not affect the actual computation. The computation (before this function is called) will still be performed as `uint16_t` on MSVC+arm neon. For e.g. the fp32-to-fp16 code will continue to pack the data in a `uint16_t` - https://github.com/ggml-org/ggml/blob/dddef738b2d5a95323188ed019877d4e20568b7e/src/ggml-impl.h#L334-L338

And the bitshifting hack from https://github.com/ggml-org/llama.cpp/pull/5404 will continue being used (in [ggml-cpu-quants.c](https://github.com/ggml-org/ggml/blob/dddef738b2d5a95323188ed019877d4e20568b7e/src/ggml-cpu/ggml-cpu-quants.c#L10961))  - https://github.com/ggml-org/ggml/blob/dddef738b2d5a95323188ed019877d4e20568b7e/src/ggml-cpu/ggml-cpu-impl.h#L91

I don't think this will affect the runtime performance, since `reinterpret_cast` is compile-time.

Given that I've never dealt with ARM code before, please let me know if this needs any changes. Thanks! :)