### PR TITLE
cpu: fix cpu backend's supports-op for GET_ROWS_BACK

### DIFF
--- a/src/ggml-cpu/ggml-cpu.cpp
+++ b/src/ggml-cpu/ggml-cpu.cpp
@@ -425,6 +425,8 @@ static bool ggml_backend_cpu_device_supports_op(ggml_backend_dev_t dev, const st
         }
         case GGML_OP_IM2COL_BACK:
             return src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F32;
+        case GGML_OP_GET_ROWS_BACK:
+            return src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16;
         case GGML_OP_OUT_PROD:
             return (src0->type == GGML_TYPE_F32 || (ggml_is_quantized(src0->type) && src0->ne[2] == src1->ne[2] && src0->ne[3] == src1->ne[3])) &&
                 src1->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32;


### PR DESCRIPTION
Minor fix. This PR fixes a fatal when running `test-backend-ops` with only the CPU backend (i.e. `test-backend-ops -b CPU`).

`GET_ROWS_BACK(type=bf16,n=256,m=5,r=4,b=1,v=0): C:\path\to\ggml\src\ggml-cpu\ops.cpp:4468: fatal error`

`GET_ROWS_BACK` [does not support `bf16`](https://github.com/ggml-org/ggml/blob/2abf606f098844faebee578996cae9c6d63a40e2/src/ggml-cpu/ops.cpp#L4451) on the CPU currently.

Not a big deal, just a minor inconsistency. I find `-b CPU` useful sometimes, for a quick "shake down" test of CPU-side changes.