### PR TITLE
Temporary fix for rms norm backward on CPU.

### DIFF
--- a/src/ggml-cpu/ops.cpp
+++ b/src/ggml-cpu/ops.cpp
@@ -3292,6 +3292,7 @@ static void ggml_compute_forward_rms_norm_back_f32(
                 //const float rms      = sqrtf(mean_eps);
                 const float rrms     = 1.0f / sqrtf(mean_eps);
                 //const float scale    = -rrms/(ne00 * mean_eps); // -1/(n*rms**3)
+                const float scale_x  = rrms * (-sum_xdz)/sum_eps;
 
                 {
                     // z = rms_norm(x)
@@ -3390,11 +3391,15 @@ static void ggml_compute_forward_rms_norm_back_f32(
                 float * dx = (float *) ((char *) dst->data + i01*nb1 + i02*nb2 + i03*nb3);
 
                 // dx[i00] = (x*(-sum_xdz/sum_eps) + dz) / sqrtf(mean_eps)
-                ggml_vec_cpy_f32  (ne00, dx, x);
+                // ggml_vec_cpy_f32  (ne00, dx, x);
                 // ggml_vec_scale_f32(ne00, dx, -mean_xdz/mean_eps);
-                ggml_vec_scale_f32(ne00, dx, (float)(-sum_xdz)/sum_eps);
-                ggml_vec_acc_f32  (ne00, dx, dz);
-                ggml_vec_scale_f32(ne00, dx, rrms);
+                // ggml_vec_scale_f32(ne00, dx, (float)(-sum_xdz)/sum_eps);
+                // ggml_vec_acc_f32  (ne00, dx, dz);
+                // ggml_vec_scale_f32(ne00, dx, rrms);
+
+                for (int64_t i00 = 0; i00 < ne00; i00++) {
+                    dx[i00] = rrms * dz[i00] + scale_x * x[i00];
+                }
             }
         }
     }


### PR DESCRIPTION
From my testing, ggml_compute_forward_rms_norm_back_f32 does not function properly on the CPU backend.

I originally noticed because CUDA seemed to be working for what I was doing, but the CPU version was completely unstable.

I made a very quick and dirty fix that seems to work from my testing, but probably shouldn't just be pulled in as is, I just wanted to call attention to ggml_compute_forward_rms_norm_back_f32 not working properly and provide a temporary fix that seems to work for specifically what I'm doing at the moment.