### PR TITLE
Explicit cast for __m512bh, __m256bh for MSVC

### DIFF
--- a/src/ggml-cpu/CMakeLists.txt
+++ b/src/ggml-cpu/CMakeLists.txt
@@ -35,7 +35,7 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
         ggml-cpu/ops.cpp
         )
 
-    target_compile_features(${GGML_CPU_NAME} PRIVATE c_std_11 cxx_std_17)
+    target_compile_features(${GGML_CPU_NAME} PRIVATE c_std_11 cxx_std_20)
     target_include_directories(${GGML_CPU_NAME} PRIVATE . ggml-cpu)
 
     if (APPLE AND GGML_ACCELERATE)

--- a/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/src/ggml-cpu/llamafile/sgemm.cpp
@@ -56,6 +56,9 @@
 #include <atomic>
 #include <array>
 #include <type_traits>
+#if defined(_MSC_VER) && defined(__AVX512BF16__)
+#include <bit>
+#endif
 
 #ifdef _MSC_VER
 #define NOINLINE __declspec(noinline)
@@ -268,10 +271,18 @@ template <> inline __m512 load(const ggml_bf16_t *p) {
 
 #if defined(__AVX512BF16__)
 template <> inline __m512bh load(const ggml_bf16_t *p) {
+#if defined(_MSC_VER)
+    return std::bit_cast<__m512bh>(_mm512_loadu_ps((const float *)p));
+#else
     return (__m512bh)_mm512_loadu_ps((const float *)p);
+#endif
 }
 template <> inline __m256bh load(const ggml_bf16_t *p) {
+#if defined(_MSC_VER)
+    return std::bit_cast<__m256bh>(_mm256_loadu_ps((const float *)p));
+#else
     return (__m256bh)_mm256_loadu_ps((const float *)p);
+#endif
 }
 template <> inline __m512bh load(const float *p) {
     return _mm512_cvtne2ps_pbh(_mm512_loadu_ps(p + 16), _mm512_loadu_ps(p));

--- a/tests/test-vec1.c
+++ b/tests/test-vec1.c
@@ -305,6 +305,7 @@ static inline uint16_t fp16_ieee_from_fp32_value(float f) {
     return (sign >> 16) | (shl1_w > UINT32_C(0xFF000000) ? UINT16_C(0x7E00) : nonsign);
 }
 
+#if defined(__F16C__)
 void mul_mat_vec_f16_0(
     const uint16_t * src0,
     const uint16_t * src1,
@@ -459,6 +460,7 @@ void mul_mat_vec_f16_3(
         }
     }
 }
+#endif
 
 uint64_t get_time_us(void) {
     struct timeval tv;
@@ -535,6 +537,7 @@ int main(int argc, const char ** argv) {
             mul_mat_vec_f32_2(src0, src1, dst, N, M);
         }
 
+#if defined(__F16C__)
         if (method == 3) {
             mul_mat_vec_f16_0(src0_fp16, src1_fp16, dst, N, M);
         }
@@ -550,6 +553,12 @@ int main(int argc, const char ** argv) {
         if (method == 6) {
             mul_mat_vec_f16_3(src0_fp16, src1, dst, N, M);
         }
+#else
+        if (method >= 3) {
+            printf("f16c not available.\n");
+            return 1;
+        }
+#endif
     }
 
     for (int i = 0; i < N; i++) {


### PR DESCRIPTION
With MSVC, a normal cast from __m512 to __m512bh and from __m256 to __m256bh does not work. I followed a suggestion in [this stackoverflow article](https://stackoverflow.com/questions/78419564/avx-512-bf16-load-bf16-values-directly-instead-of-converting-from-fp32/78422135#78422135), using std::bit_cast, and it works. It requires compilation to C++-20 standards, however.