### PR TITLE
Enable UTF-8 Source Encoding for MSVC via CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  workflow_dispatch: # allows manual triggering
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch: # allows manual triggering
   push:
     branches: [ master ]
   pull_request:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,6 @@ option(GGML_BACKEND_DL   "ggml: build backends as dynamic libraries (requires BU
 if (MSVC)
     add_compile_options("$<$<COMPILE_LANGUAGE:C>:/utf-8>")
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/utf-8>")
-    add_compile_options("$<$<COMPILE_LANGUAGE:C>:/bigobj>")
-    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/bigobj>")
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,14 @@ endif()
 option(BUILD_SHARED_LIBS "ggml: build shared libraries" ${BUILD_SHARED_LIBS_DEFAULT})
 option(GGML_BACKEND_DL   "ggml: build backends as dynamic libraries (requires BUILD_SHARED_LIBS)" OFF)
 
+
+if (MSVC)
+    add_compile_options("$<$<COMPILE_LANGUAGE:C>:/utf-8>")
+    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/utf-8>")
+    add_compile_options("$<$<COMPILE_LANGUAGE:C>:/bigobj>")
+    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/bigobj>")
+endif()
+
 #
 # option list
 #


### PR DESCRIPTION
Add conditional CMake compiler options so that when building with MSVC, both C and C++ sources are compiled with UTF-8 encoding (/utf-8). By default, MSVC uses the system code page and will warn (C4819) or fail when encountering non-ASCII characters in source files. This change eliminates those encoding warnings without requiring BOMs or pragmas in the code, ensures consistent UTF-8 handling across platforms, and keeps existing build processes for other toolchains unchanged.