### PR TITLE
ggml : Fix missing backtrace on Linux with lldb and/or ptrace_scope=1

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -70,6 +70,9 @@ float ggml_table_f32_f16[1 << 16];
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#if defined(__linux__)
+#include <sys/prctl.h>
+#endif
 
 #if defined(__ANDROID__)
 #include <unwind.h>
@@ -133,10 +136,36 @@ static void ggml_print_backtrace(void) {
     if (GGML_NO_BACKTRACE) {
         return;
     }
-    char attach[32];
-    snprintf(attach, sizeof(attach), "attach %d", getpid());
-    int pid = fork();
-    if (pid == 0) {
+#if defined(__linux__)
+    FILE * f = fopen("/proc/self/status", "r");
+    size_t size = 0;
+    char * line = NULL;
+    ssize_t length = 0;
+    while ((length = getline(&line, &size, f)) > 0) {
+        if (!strncmp(line, "TracerPid:", sizeof("TracerPid:") - 1) &&
+            (length != sizeof("TracerPid:\t0\n") - 1 || line[length - 2] != '0')) {
+            // Already being debugged, and the breakpoint is the later abort()
+            free(line);
+            fclose(f);
+            return;
+        }
+    }
+    free(line);
+    fclose(f);
+    int lock[2] = { -1, -1 };
+    (void) !pipe(lock); // Don't start gdb until after PR_SET_PTRACER
+#endif
+    const int parent_pid = getpid();
+    const int child_pid = fork();
+    if (child_pid < 0) { // error
+        return;
+    } else if (child_pid == 0) { // child
+        char attach[32];
+        snprintf(attach, sizeof(attach), "attach %d", parent_pid);
+#if defined(__linux__)
+        close(lock[1]);
+        (void) !read(lock[0], lock, 1);
+#endif
         // try gdb
         execlp("gdb", "gdb", "--batch",
             "-ex", "set style enabled on",
@@ -149,18 +178,18 @@ static void ggml_print_backtrace(void) {
         execlp("lldb", "lldb", "--batch",
             "-o", "bt",
             "-o", "quit",
-            "-p", attach,
+            "-p", &attach[sizeof("attach ") - 1],
             (char *) NULL);
-        exit(EXIT_FAILURE);
-    } else {
-        int wstatus;
-        waitpid(pid, &wstatus, 0);
-        if (WIFEXITED(wstatus)) {
-            if (WEXITSTATUS(wstatus) == EXIT_FAILURE) {
-                // gdb failed, fallback to backtrace_symbols
-                ggml_print_backtrace_symbols();
-            }
-        }
+        // gdb failed, fallback to backtrace_symbols
+        ggml_print_backtrace_symbols();
+        _Exit(0);
+    } else { // parent
+#if defined(__linux__)
+        prctl(PR_SET_PTRACER, child_pid);
+        close(lock[1]);
+        close(lock[0]);
+#endif
+        waitpid(child_pid, NULL, 0);
     }
 }
 #else


### PR DESCRIPTION
This fixes the backtraces being broken debugger-absent and the error message clutter debugger-present. This also fixes lldb not working when gdb isn't installed.

# Before

```console
$ ./simple-ctx # lldb
/home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp:75: test
error: Could not convert process PID: "attach 68331" into a pid.
$ ./simple-ctx # gdb
/home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp:75: test
Could not attach to process.  If your uid matches the uid of the target
process, check the setting of /proc/sys/kernel/yama/ptrace_scope, or try
again as the root user.  For more details, see /etc/sysctl.d/10-ptrace.conf
ptrace: Operation not permitted.
No stack.
The program is not being run.
Aborted (core dumped)
$ gdb ./simple-ctx
GNU gdb (Ubuntu 15.1-1ubuntu2) 15.1
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./simple-ctx...
(gdb) start
Temporary breakpoint 1 at 0x1550: file /home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp, line 74.
Starting program: /home/home/CLionProjects/ggml/cmake-build-debug/bin/simple-ctx 

This GDB supports auto-downloading debuginfo from the following URLs:
  <https://debuginfod.ubuntu.com>
Enable debuginfod for this session? (y or [n]) n
Debuginfod has been disabled.
To make this setting permanent, add 'set debuginfod enabled off' to .gdbinit.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Temporary breakpoint 1, main () at /home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp:74
74      int main(void) {
(gdb) c
Continuing.
/home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp:75: test
[Detaching after fork from child process 48239]
Could not attach to process.  If your uid matches the uid of the target
process, check the setting of /proc/sys/kernel/yama/ptrace_scope, or try
again as the root user.  For more details, see /etc/sysctl.d/10-ptrace.conf
warning: process 48236 is already traced by process 48226
ptrace: Operation not permitted.
No stack.
The program is not being run.

Program received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=6, no_tid=0) at ./nptl/pthread_kill.c:44
warning: 44     ./nptl/pthread_kill.c: No such file or directory
(gdb) q
A debugging session is active.

        Inferior 1 [process 48236] will be killed.

Quit anyway? (y or n) y
```

# After

```console
$ ./simple-ctx # lldb
/home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp:75: test
(lldb) process attach --pid 68938
Process 68938 stopped
* thread #1, name = 'simple-ctx', stop reason = signal SIGSTOP
    frame #0: 0x00007fe76e91a127 libc.so.6`__GI___wait4(pid=68939, stat_loc=0x0000000000000000, options=0, usage=0x0000000000000000) at wait4.c:30:10
Executable module set to "/home/home/CLionProjects/ggml/buildninja/bin/simple-ctx".
Architecture set to: x86_64-pc-linux-gnu.
(lldb) bt
* thread #1, name = 'simple-ctx', stop reason = signal SIGSTOP
  * frame #0: 0x00007fe76e91a127 libc.so.6`__GI___wait4(pid=68939, stat_loc=0x0000000000000000, options=0, usage=0x0000000000000000) at wait4.c:30:10
    frame #1: 0x00007fe76ebf8c08 libggml-base.so`ggml_abort + 520
    frame #2: 0x000056536f13d204 simple-ctx`main + 36
    frame #3: 0x00007fe76e82a3b8 libc.so.6`__libc_start_call_main(main=(simple-ctx`main), argc=1, argv=0x00007ffcc6111c58) at libc_start_call_main.h:58:16
    frame #4: 0x00007fe76e82a47b libc.so.6`__libc_start_main_impl(main=(simple-ctx`main), argc=1, argv=0x00007ffcc6111c58, init=<unavailable>, fini=<unavailable>, rtld_fini=<unavailable>, stack_end=0x00007ffcc6111c48) at libc-start.c:360:3
    frame #5: 0x000056536f13d235 simple-ctx`_start + 37
(lldb) quit
Aborted (core dumped)
$ ./simple-ctx # gdb
/home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp:75: test

This GDB supports auto-downloading debuginfo from the following URLs:
  <https://debuginfod.ubuntu.com>
Enable debuginfod for this session? (y or [n]) [answered N; input not from terminal]
Debuginfod has been disabled.
To make this setting permanent, add 'set debuginfod enabled off' to .gdbinit.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
0x00007f35ceb1a127 in __GI___wait4 (pid=48748, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
warning: 30     ../sysdeps/unix/sysv/linux/wait4.c: No such file or directory
#0  0x00007f35ceb1a127 in __GI___wait4 (pid=48748, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
30      in ../sysdeps/unix/sysv/linux/wait4.c
#1  0x00007f35cee4546c in ggml_print_backtrace () at /home/home/CLionProjects/ggml/src/ggml.c:190
190             waitpid(child_pid, NULL, 0);
#2  0x00007f35cee4559f in ggml_abort (file=0x55a0514ce018 "/home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp", line=75, fmt=0x55a0514ce010 "test") at /home/home/CLionProjects/ggml/src/ggml.c:211
211         ggml_print_backtrace();
#3  0x000055a0514cd596 in main () at /home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp:75
75          GGML_ABORT("test");
[Inferior 1 (process 48747) detached]
Aborted (core dumped)
$ gdb ./simple-ctx
GNU gdb (Ubuntu 15.1-1ubuntu2) 15.1
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./simple-ctx...
(gdb) start
Temporary breakpoint 1 at 0x1550: file /home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp, line 74.
Starting program: /home/home/CLionProjects/ggml/cmake-build-debug/bin/simple-ctx 

This GDB supports auto-downloading debuginfo from the following URLs:
  <https://debuginfod.ubuntu.com>
Enable debuginfod for this session? (y or [n]) n
Debuginfod has been disabled.
To make this setting permanent, add 'set debuginfod enabled off' to .gdbinit.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Temporary breakpoint 1, main () at /home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp:74
74      int main(void) {
(gdb) c
Continuing.
/home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp:75: test

Program received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=6, no_tid=0) at ./nptl/pthread_kill.c:44
warning: 44     ./nptl/pthread_kill.c: No such file or directory
(gdb) 
```