### PR TITLE
ggml : fix apple OS check in ggml_print_backtrace

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -64,8 +64,10 @@
 // precomputed f32 table for f16 (256 KB) (ggml-impl.h)
 float ggml_table_f32_f16[1 << 16];
 
-#if (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)) && \
-    (!defined(TARGET_OS_TV) && !defined(TARGET_OS_WATCH))
+#if defined(__linux__) || \
+    defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+    (defined(__APPLE__) && !TARGET_OS_TV && !TARGET_OS_WATCH)
+
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Fixed condition that prevented `ggml_print_backtrace` from working on Apple systems. `TARGET_OS_TV` and `TARGET_OS_WATCH` may be defined, but zero.