### PR TITLE
ggml : Print backtrace on uncaught C++ exceptions

### DIFF
--- a/src/ggml-threading.cpp
+++ b/src/ggml-threading.cpp
@@ -1,4 +1,5 @@
 #include "ggml-threading.h"
+#include <exception>
 #include <mutex>
 
 std::mutex ggml_critical_section_mutex;
@@ -9,4 +10,21 @@ void ggml_critical_section_start() {
 
 void ggml_critical_section_end(void) {
     ggml_critical_section_mutex.unlock();
+}
+
+GGML_NORETURN static void ggml_uncaught_exception() {
+    if (const std::exception_ptr e{std::current_exception()}) {
+        try {
+            std::rethrow_exception(e);
+        } catch (const std::exception & ex) {
+            ggml_abort("set_terminate", 0, "uncaught exception %s", ex.what());
+        } catch (...) {
+            ggml_abort("set_terminate", 0, "unknown exception");
+        }
+    }
+    ggml_abort("set_terminate", 0, "std::terminate called");
+}
+
+void ggml_uncaught_exception_init() {
+    std::set_terminate(ggml_uncaught_exception);
 }

--- a/src/ggml-threading.h
+++ b/src/ggml-threading.h
@@ -9,6 +9,8 @@ extern "C" {
 GGML_API void ggml_critical_section_start(void);
 GGML_API void ggml_critical_section_end(void);
 
+void ggml_uncaught_exception_init(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -160,6 +160,10 @@ static void ggml_print_backtrace(void) {
     const int parent_pid = getpid();
     const int child_pid = fork();
     if (child_pid < 0) { // error
+#if defined(__linux__)
+        close(lock[1]);
+        close(lock[0]);
+#endif
         return;
     } else if (child_pid == 0) { // child
         char attach[32];
@@ -167,6 +171,7 @@ static void ggml_print_backtrace(void) {
 #if defined(__linux__)
         close(lock[1]);
         (void) !read(lock[0], lock, 1);
+        close(lock[0]);
 #endif
         // try gdb
         execlp("gdb", "gdb", "--batch",
@@ -215,6 +220,8 @@ void ggml_abort(const char * file, int line, const char * fmt, ...) {
     ggml_print_backtrace();
     abort();
 }
+
+// ggml_abort is registered with std::set_terminate by ggml-threading.cpp
 
 //
 // logging
@@ -1417,6 +1424,7 @@ struct ggml_context * ggml_init(struct ggml_init_params params) {
     if (is_first_call) {
         // initialize time system (required on Windows)
         ggml_time_init();
+        ggml_uncaught_exception_init();
 
         for (int i = 0; i < (1 << 16); ++i) {
             union {


### PR DESCRIPTION
The goal is to have what users call "[full logs](https://github.com/ggml-org/whisper.cpp/issues/3168)" contain the backtrace.

This is registered upon ggml_init. Also fixes a minor fd [leak](https://github.com/ggml-org/ggml/pull/1228#discussion_r2094299456) on Linux.

# Before

```text
/home/home/CLionProjects/ggml/cmake-build-debug/bin/simple-ctx
terminate called after throwing an instance of 'std::runtime_error'
  what():  test

Process finished with exit code 134 (interrupted by signal 6:SIGABRT)
```

# After

```text
/home/home/CLionProjects/ggml/cmake-build-debug/bin/simple-ctx
set_terminate:0: uncaught exception test
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
warning: 30	../sysdeps/unix/sysv/linux/wait4.c: No such file or directory
0x00007f1711d1a127 in __GI___wait4 (pid=311685, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
#0  0x00007f1711d1a127 in __GI___wait4 (pid=311685, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
30	in ../sysdeps/unix/sysv/linux/wait4.c
#1  0x00007f17124c2601 in ggml_print_backtrace () at /home/home/CLionProjects/ggml/src/ggml.c:199
199	        waitpid(child_pid, NULL, 0);
#2  0x00007f17124c2731 in ggml_abort (file=0x7f171254301e "set_terminate", line=0, fmt=0x7f171254302c "uncaught exception %s") at /home/home/CLionProjects/ggml/src/ggml.c:220
220	    ggml_print_backtrace();
#3  0x00007f17124ee3a0 in ggml_uncaught_exception () at /home/home/CLionProjects/ggml/src/ggml-threading.cpp:20
20	            ggml_abort("set_terminate", 0, "uncaught exception %s", ex.what());
#4  0x00007f17120bb0da in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007f17120a5a55 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f17120bb391 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x000055e5756e1763 in main () at /home/home/CLionProjects/ggml/examples/simple/simple-ctx.cpp:101
101	        throw std::runtime_error("test");
[Inferior 1 (process 311684) detached]

Process finished with exit code 134 (interrupted by signal 6:SIGABRT)
```