### PR TITLE
ggml : remove ggml_graph_import and ggml_graph_export declarations

### DIFF
--- a/examples/python/ggml/__init__.pyi
+++ b/examples/python/ggml/__init__.pyi
@@ -934,14 +934,8 @@ class lib:
         GGML_API void ggml_graph_dump_dot(const struct ggml_cgraph * gb, const struct ggml_cgraph * gf, const char * filename);
     """
     ...
-  def ggml_graph_export(cgraph: ffi.CData, fname: ffi.CData) -> None:
-    """    GGML_API void               ggml_graph_export(const struct ggml_cgraph * cgraph, const char * fname);"""
-    ...
   def ggml_graph_get_tensor(cgraph: ffi.CData, name: ffi.CData) -> ffi.CData:
     """    GGML_API struct ggml_tensor * ggml_graph_get_tensor(struct ggml_cgraph * cgraph, const char * name);"""
-    ...
-  def ggml_graph_import(fname: ffi.CData, ctx_data: ffi.CData, ctx_eval: ffi.CData) -> ffi.CData:
-    """    GGML_API struct ggml_cgraph ggml_graph_import(const char * fname, struct ggml_context ** ctx_data, struct ggml_context ** ctx_eval);"""
     ...
   def ggml_graph_overhead() -> int:
     """    GGML_API size_t ggml_graph_overhead(void);"""

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -2086,9 +2086,6 @@ extern "C" {
     GGML_API struct ggml_tensor * ggml_graph_get_grad    (const struct ggml_cgraph * cgraph, const struct ggml_tensor * node);
     GGML_API struct ggml_tensor * ggml_graph_get_grad_acc(const struct ggml_cgraph * cgraph, const struct ggml_tensor * node);
 
-    GGML_API void                 ggml_graph_export(const struct ggml_cgraph * cgraph, const char * fname);
-    GGML_API struct ggml_cgraph * ggml_graph_import(const char * fname, struct ggml_context ** ctx_data, struct ggml_context ** ctx_eval);
-
     // print info and performance information for the graph
     GGML_API void ggml_graph_print(const struct ggml_cgraph * cgraph);
 


### PR DESCRIPTION
The implementation is already deleted with commit 9d0762e.

ref: #1235