### PR TITLE
ggml : fix pkg-config include path

### DIFF
--- a/ggml.pc.in
+++ b/ggml.pc.in
@@ -6,5 +6,5 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 Name: ggml
 Description: The GGML Tensor Library for Machine Learning
 Version: 0.0.0
-Cflags: -I${includedir}/ggml
+Cflags: -I${includedir}
 Libs: -L${libdir} -lggml


### PR DESCRIPTION
CMake is installing public headers in CMAKE_INSTALL_INCLUDEDIR, not CMAKE_INSTALL_INCLUDEDIR/ggml.

This patch fixes building external programs which use 'pkg-config --cflags ggml'