### PR TITLE
Allow stand-alone build of simple example

### DIFF
--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,16 +1,30 @@
 #
+# This example can be built as part of ggml or
+# as a separate project with an installed ggml.
+
+cmake_minimum_required(VERSION 3.14)
+project(ggml-simple)
+
+if (NOT TARGET ggml::ggml)
+    # Building as a separate project
+    find_package(ggml CONFIG REQUIRED)
+
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
+#
 # simple-ctx
 
 set(TEST_TARGET simple-ctx)
 add_executable(${TEST_TARGET} simple-ctx.cpp)
-target_link_libraries(${TEST_TARGET} PRIVATE ggml)
+target_link_libraries(${TEST_TARGET} PRIVATE ggml::ggml)
 
 #
 # simple-backend
 
 set(TEST_TARGET simple-backend)
 add_executable(${TEST_TARGET} simple-backend.cpp)
-target_link_libraries(${TEST_TARGET} PRIVATE ggml)
+target_link_libraries(${TEST_TARGET} PRIVATE ggml::ggml)
 
 if (GGML_CUDA)
     add_compile_definitions(GGML_USE_CUDA)


### PR DESCRIPTION
This helps to validate the installed package.

It also shows a benefit of the other change: An in-build `ggml::ggml` ALIAS enables a uniform link library name regardless of ggml being used as a sub-project or via `find_package`.