### PR TITLE
mnist : use CMake to build mnist wasm example

### DIFF
--- a/examples/mnist/CMakeLists.txt
+++ b/examples/mnist/CMakeLists.txt
@@ -18,3 +18,41 @@ target_link_libraries(${TEST_TARGET} PRIVATE ggml common mnist-common)
 set(TEST_TARGET mnist-train)
 add_executable(${TEST_TARGET} mnist-train.cpp)
 target_link_libraries(${TEST_TARGET} PRIVATE ggml common mnist-common)
+
+
+#
+# mnist-wasm
+if (EMSCRIPTEN)
+    set(TARGET mnist)
+
+    add_executable(${TARGET} mnist-common.cpp)
+    target_link_libraries(${TARGET} PRIVATE ggml ggml-cpu)
+
+    set_target_properties(${TARGET} PROPERTIES LINK_FLAGS " \
+        --bind \
+        -s FORCE_FILESYSTEM=1 \
+        -s USE_PTHREADS=1 \
+        -s PTHREAD_POOL_SIZE=10 \
+        -s ASSERTIONS=1 \
+        -s WASM=1 \
+        -s EXPORTED_RUNTIME_METHODS=\"['ccall', 'cwrap', 'setValue', 'getValue']\" \
+        -s EXPORTED_FUNCTIONS=\"['_wasm_eval','_wasm_random_digit','_malloc','_free']\" \
+        -s ALLOW_MEMORY_GROWTH=1 \
+        --preload-file ${CMAKE_CURRENT_SOURCE_DIR}/mnist-f32.gguf@/ \
+        --preload-file ${CMAKE_CURRENT_SOURCE_DIR}/t10k-images-idx3-ubyte@/ \
+        ")
+
+    # Copy output to web directory
+    add_custom_command(
+        TARGET ${TARGET} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_BINARY_DIR}/bin/mnist.js
+            ${CMAKE_CURRENT_SOURCE_DIR}/web/mnist.js
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_BINARY_DIR}/bin/mnist.wasm
+            ${CMAKE_CURRENT_SOURCE_DIR}/web/mnist.wasm
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_BINARY_DIR}/bin/mnist.worker.js
+            ${CMAKE_CURRENT_SOURCE_DIR}/web/mnist.worker.js
+        )
+endif()

--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -178,18 +178,23 @@ Symlinking these files will *not* work!
 Compile the code like so:
 
 ```bash
-$ emcc -I../../include -I../../include/ggml -I../../examples ../../src/ggml.c ../../src/ggml-quants.c ../../src/ggml-aarch64.c mnist-common.cpp -o web/mnist.js -s EXPORTED_FUNCTIONS='["_wasm_eval","_wasm_random_digit","_malloc","_free"]' -s EXPORTED_RUNTIME_METHODS='["ccall"]' -s ALLOW_MEMORY_GROWTH=1 --preload-file mnist-f32.gguf --preload-file t10k-images-idx3-ubyte
+$ cd ../../
+$ mkdir -p build-em
+$ emcmake cmake .. -DGGML_BUILD_EXAMPLES=ON \
+    -DCMAKE_C_FLAGS="-pthread -matomics -mbulk-memory" \
+    -DCMAKE_CXX_FLAGS="-pthread -matomics -mbulk-memory"
+$ make mnist
 ```
 
-The compilation output is in `examples/mnist/web`.
+The compilation output is copied into `examples/mnist/web`.
 To run it, you need an HTTP server.
 For example:
 
 ``` bash
-$ cd web
-$ python3 -m http.server
+$ python3 examples/mnist/server.py
 
-Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
+Serving directory '/home/danbev/work/ai/ggml/examples/mnist/web' at http://localhost:8000
+Application context root: http://localhost:8000/
 ```
 
 The web demo can then be accessed via the link printed on the console.

--- a/examples/mnist/server.py
+++ b/examples/mnist/server.py
@@ -1,0 +1,36 @@
+import http.server
+import socketserver
+import os
+import sys
+
+DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), 'web'))
+PORT = 8000
+
+class CustomHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=DIRECTORY, **kwargs)
+
+    def end_headers(self):
+        # Add required headers for SharedArrayBuffer
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        super().end_headers()
+
+# Enable address reuse
+class CustomServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+try:
+    with CustomServer(("", PORT), CustomHTTPRequestHandler) as httpd:
+        print(f"Serving directory '{DIRECTORY}' at http://localhost:{PORT}")
+        print(f"Application context root: http://localhost:{PORT}/")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\nServer stopped.")
+            # Force complete exit
+            sys.exit(0)
+except OSError as e:
+    print(f"Error: {e}")
+    sys.exit(1)


### PR DESCRIPTION
This commit updates the mnist examples to use CMake for building the WebAssembly (WASM) version of the MNIST example instead of the current emcc command.

The motivation for this change is that using CMake should make it easier to maintin with regards to when changes in ggml occur they should not cause this example to break. Currently the emcc command is outdated and it was not clear how to updated it which is why this change was made.

Resolves: https://github.com/ggml-org/ggml/issues/1264