### PR TITLE
scripts : remove common.{cpp,h} from whisper sync scripts

### DIFF
--- a/scripts/sync-whisper-am.sh
+++ b/scripts/sync-whisper-am.sh
@@ -74,8 +74,6 @@ while read c; do
         ggml/src/ggml-vulkan/* \
         ggml/include/ggml*.h \
         ggml/include/gguf*.h \
-        examples/common.h \
-        examples/common.cpp \
         examples/common-ggml.h \
         examples/common-ggml.cpp \
         LICENSE \

--- a/scripts/sync-whisper.sh
+++ b/scripts/sync-whisper.sh
@@ -24,8 +24,6 @@ cp -rpv ../whisper.cpp/ggml/src/ggml-vulkan/*    src/ggml-vulkan/
 cp -rpv ../whisper.cpp/ggml/include/ggml*.h include/
 cp -rpv ../whisper.cpp/ggml/include/gguf*.h include/
 
-cp -rpv ../whisper.cpp/examples/common.h        examples/common.h
-cp -rpv ../whisper.cpp/examples/common.cpp      examples/common.cpp
 cp -rpv ../whisper.cpp/examples/common-ggml.h   examples/common-ggml.h
 cp -rpv ../whisper.cpp/examples/common-ggml.cpp examples/common-ggml.cpp
 


### PR DESCRIPTION
This commit removes the common.{cpp,h} files from the whisper sync scripts.

Refs: https://github.com/ggml-org/whisper.cpp/pull/3244#issuecomment-2966630744