### PR TITLE
ggml : remove unused ggml_context_container

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -888,12 +888,6 @@ struct ggml_context {
     struct ggml_object * objects_end;
 };
 
-struct ggml_context_container {
-    bool used;
-
-    struct ggml_context context;
-};
-
 //
 // data types
 //


### PR DESCRIPTION
This commit removes the unused `ggml_context_container` structure from the ggml library. It looks like the usage of this struct was removed in Commit 4757fe18d56ec11bf9c07feaca6e9d5b5357e7f4 ("ggml : alloc ggml_contexts on the heap (whisper/2525)").

The motivation for this changes is to improve code clarity/readability.