### PR TITLE
build : fix build with clang-cl on Windows

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -203,7 +203,7 @@ if (NOT GGML_BACKEND_DL)
     add_executable(${TEST_TARGET} ${TEST_TARGET}.c)
     target_link_libraries(${TEST_TARGET} PRIVATE ggml)
     if (MSVC)
-        target_link_options(${TEST_TARGET} PRIVATE "/STACK: 8388608") # 8MB
+        target_link_options(${TEST_TARGET} PRIVATE "/STACK:8388608") # 8MB
     endif()
     add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
     set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")
@@ -215,7 +215,7 @@ if (NOT GGML_BACKEND_DL)
     add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
     target_link_libraries(${TEST_TARGET} PRIVATE ggml Threads::Threads)
     if (MSVC)
-        target_link_options(${TEST_TARGET} PRIVATE "/STACK: 8388608") # 8MB
+        target_link_options(${TEST_TARGET} PRIVATE "/STACK:8388608") # 8MB
     endif()
     add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
     set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")
@@ -227,7 +227,7 @@ if (NOT GGML_BACKEND_DL)
     add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
     target_link_libraries(${TEST_TARGET} PRIVATE ggml)
     if (MSVC)
-        target_link_options(${TEST_TARGET} PRIVATE "/STACK: 8388608") # 8MB
+        target_link_options(${TEST_TARGET} PRIVATE "/STACK:8388608") # 8MB
     endif()
     add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
     set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")
@@ -286,7 +286,7 @@ if (NOT GGML_BACKEND_DL)
     add_executable(${TEST_TARGET} ${TEST_TARGET}.c)
     target_link_libraries(${TEST_TARGET} PRIVATE ggml)
     if (MSVC)
-        target_link_options(${TEST_TARGET} PRIVATE "/STACK: 8388608") # 8MB
+        target_link_options(${TEST_TARGET} PRIVATE "/STACK:8388608") # 8MB
     endif()
     add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
     set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")

--- a/tests/test-roll.cpp
+++ b/tests/test-roll.cpp
@@ -22,7 +22,7 @@ int64_t wrap(int64_t i, int64_t ne) {
 }
 
 std::vector<float> roll_reference(
-    const float * src, std::array<int64_t, 4> ne, std::array<int64_t, 4> shift) {
+    const float * src, std::array<int64_t, 4> ne, std::array<int, 4> shift) {
 
     const int64_t ne0 = ne[0], ne1 = ne[1], ne2 = ne[2], ne3 = ne[3];
     std::vector<float> dst(ne0 * ne1 * ne2 * ne3);
@@ -45,7 +45,7 @@ std::vector<float> roll_reference(
     return dst;
 }
 
-std::vector<float> f32_range(int n) {
+std::vector<float> f32_range(int64_t n) {
     std::vector<float> values(n);
     std::iota(values.begin(), values.end(), 0.f);
     return values;
@@ -65,7 +65,7 @@ bool check_equal(const std::vector<float> & result, const std::vector<float> & e
     return true;
 }
 
-bool test_roll(std::array<int64_t, 4> ne, std::array<int64_t, 4> shift, bool permute) {
+bool test_roll(std::array<int64_t, 4> ne, std::array<int, 4> shift, bool permute) {
     ggml_time_init();
 
     ggml_init_params params {


### PR DESCRIPTION
clang-cl.exe (clang with MSVC-like CLI) fails to compile some tests because it doesn't like the space in /STACK option.
I tested with regular cl.exe (MSVC) and it doesn't need the space (works either way).

Also fixes compiler warnings about conversions with MSVC.