### PR TITLE
ggml : add version function to get lib version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,9 @@ write_basic_package_version_file(
     VERSION ${GGML_INSTALL_VERSION}
     COMPATIBILITY SameMajorVersion)
 
+target_compile_definitions(ggml-base PRIVATE GGML_VERSION="${GGML_INSTALL_VERSION}")
+message(STATUS "ggml version: ${GGML_INSTALL_VERSION}")
+
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ggml-config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/ggml-version.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ggml)

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -627,6 +627,8 @@ extern "C" {
 
     // misc
 
+    GGML_API const char * ggml_version(void);
+
     GGML_API void    ggml_time_init(void); // call this once at the beginning of the program
     GGML_API int64_t ggml_time_ms(void);
     GGML_API int64_t ggml_time_us(void);

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -461,6 +461,10 @@ bool ggml_guid_matches(ggml_guid_t guid_a, ggml_guid_t guid_b) {
     return memcmp(guid_a, guid_b, sizeof(ggml_guid)) == 0;
 }
 
+const char * ggml_version(void) {
+    return GGML_VERSION;
+}
+
 //
 // timing
 //


### PR DESCRIPTION
This commit adds a function `ggml_version()` to the ggml library that returns the version of the library as a string.

The motivation for this is that it can be useful to be able to programmatically check the version of the ggml library being used.

Usage:
```c
printf("GGML version: %s\n", ggml_version());
```
Output:
```console
GGML version: 0.0.2219
```