### PR TITLE
fix dequant_funcs.comp

### DIFF
--- a/src/ggml-vulkan/vulkan-shaders/dequant_funcs.comp
+++ b/src/ggml-vulkan/vulkan-shaders/dequant_funcs.comp
@@ -442,8 +442,12 @@ vec2 get_dm(uint ib, uint a_offset) {
 
 #if defined(DATA_A_IQ1_M)
 vec2 get_dm(uint ib, uint a_offset) {
-    const uint16_t[4] scales = data_a[a_offset + ib].scales;
-    const u16vec4 s = u16vec4(scales[0], scales[1], scales[2], scales[3]) >> 12;
+    u16vec4 s = u16vec4(
+        data_a[a_offset + ib].scales[0],
+        data_a[a_offset + ib].scales[1],
+        data_a[a_offset + ib].scales[2],
+        data_a[a_offset + ib].scales[3]
+    ) >> 12;
     const float d = float(unpackHalf2x16(s.x | (s.y << 4) | (s.z << 8) | (s.w << 12)).x);
     return vec2(d, 0);
 }


### PR DESCRIPTION
`data_a` is decorated with layout specifiers, so copying it causes the destination to receive those layout specifiers as well. this is illegal for function-local arrays. `spirv` accepts this code for compilation, but the resulting bytecode is against the rules so `spirv-opt` barfs.

*For changes to the core `ggml` library (including to the CMake build system), please open a PR in https://github.com/ggml-org/llama.cpp. Doing so will make your PR more visible, better tested and more likely to be reviewed.*
