### PR TITLE
CI: Move msvc to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,14 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
         libraries: [shared, static]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Clone
+      uses: actions/checkout@v4
 
     - name: Dependencies for Ubuntu
       if: matrix.os == 'ubuntu-latest'
@@ -24,56 +25,35 @@ jobs:
         sudo apt-get update
         sudo apt-get install llvm
 
+    - name: Add msbuild to PATH
+      if: matrix.os == 'windows-latest'
+      uses: microsoft/setup-msbuild@v2
+
     - name: Create Build Environment
       run: mkdir build
 
     - name: Configure CMake
       working-directory: ./build
       run: cmake ..
-        -G Ninja
-        -DCMAKE_C_COMPILER=clang
-        -DCMAKE_CXX_COMPILER=clang++
+        ${{ contains(matrix.os, 'windows') && '-A x64' || '-G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++' }}
+        ${{ matrix.libraries == 'static' && '-DBUILD_SHARED_LIBS=OFF' || '-DBUILD_SHARED_LIBS=ON' }}
         -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/installed
         -DGGML_METAL=OFF
-        ${{ contains(matrix.libraries, 'static') && '-DBUILD_SHARED_LIBS=OFF' || '-DBUILD_SHARED_LIBS=ON' }}
 
     - name: Build
       working-directory: ./build
-      run: cmake --build .
+      run: cmake --build . ${{ contains(matrix.os, 'windows') && '--config Release' || '' }}
 
     - name: Test
       working-directory: ./build
-      run: ctest --verbose --timeout 900
+      run: ctest --verbose --timeout 900 ${{ contains(matrix.os, 'windows') && '--build-config Release' || '' }}
 
     - name: Install
       working-directory: ./build
-      run: cmake --build . --target install
+      run: cmake --build . --target install ${{ contains(matrix.os, 'windows') && '--config Release' || '' }}
 
     - name: Test CMake config
       run: |
         mkdir test-cmake
-        cmake -S examples/test-cmake -B test-cmake -DCMAKE_PREFIX_PATH=${{ github.workspace }}/installed
-        cmake --build test-cmake
-
-  windows:
-    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
-            github.event.inputs.run_type == 'full-ci' }}
-    runs-on: windows-latest
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Configure
-        run: >
-          cmake -S . -B ./build -A x64
-          -DCMAKE_BUILD_TYPE=Release
-          -DBUILD_SHARED_LIBS=ON
-
-      - name: Build
-        run: |
-          cd ./build
-          msbuild ALL_BUILD.vcxproj -t:build -p:configuration=Release -p:platform=x64
+        cmake -S examples/test-cmake -B test-cmake -DCMAKE_PREFIX_PATH=${{ github.workspace }}/installed ${{ contains(matrix.os, 'windows') && '-A x64' || '-G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++' }}
+        cmake --build test-cmake ${{ contains(matrix.os, 'windows') && '--config Release' || '' }}


### PR DESCRIPTION
Enable static builds and testing.

... except that the test results must be ignored for Windows: `test-timestep_embedding` is flaky. The actual result doesn't always match the expected result. Example:
~~~
 6/19 Test  #6: test-arange ......................   Passed    0.01 sec
test 7
      Start  7: test-timestep_embedding

7: Test command: D:\a\ggml\ggml\build\bin\Release\test-timestep_embedding.exe
7: Working Directory: D:/a/ggml/ggml/build/tests
7: Environment variables: 
7:  LLVM_PROFILE_FILE=test-timestep_embedding.profraw
7: Test timeout computed to be: 900
7: 0.8439 -0.9970 0.6497 0.9733 0.9981 0.9999 1.0000 -0.5366 -0.0776 0.7602 0.2296 0.0621 0.0167 0.0045 0.0000 0.0000 0.4242 0.9880 -0.1558 0.8946 0.9923 0.9994 1.0000 -0.9056 0.1547 0.9878 0.4470 0.1240 0.0333 0.0089 0.0000 0.0000 
7: -----------------------------------
7: 0.8439 -0.9970 0.6497 0.9733 0.9981 0.9999 1.0000 -0.5366 -0.0776 0.7602 0.2296 0.0621 0.0167 0.0045 242.7236 D:\a\ggml\ggml\tests\test-timestep_embedding.cpp:171: GGML_ASSERT(equalsf(output[i], expected_result[i])) failed
 7/19 Test  #7: test-timestep_embedding ..........Exit code 0xc0000409
***Exception:   0.29 sec
~~~
Cf. "Msvc" runs in https://github.com/dg0yt/ggml/actions/workflows/ci.yml.
All errors occured for expected value `0`.
Tests didn't run for MSVC before this PR, so the test failure isn't a regression.

I didn't check if there is another way to exclude the flaky test. 

