### PR TITLE
ci : add github release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Configure CMake
-      run: |
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-
-    - name: Build source package
-      run: |
-        cmake --build build --target ggml_package
-        mkdir -p release
-        cp build/ggml-src.zip release/
-
     - name: Create Release
       id: create_release
       uses: ggml-org/action-create-release@v1
@@ -35,25 +25,3 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-
-    - name: Upload release
-      id: upload_release
-      uses: actions/github-script@v3
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const path = require('path');
-          const fs = require('fs');
-          const release_id = '${{ steps.create_release.outputs.id }}';
-          for (let file of await fs.readdirSync('./release')) {
-              if (path.extname(file) === '.zip') {
-                console.log('uploadReleaseAsset', file);
-                await github.repos.uploadReleaseAsset({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  release_id: release_id,
-                  name: file,
-                  data: await fs.readFileSync(`./release/${file}`)
-                });
-              }
-            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Configure CMake
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build source package
+      run: cmake --build build --target ggml_package
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: build/ggml-src.zip
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,40 @@ jobs:
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 
     - name: Build source package
-      run: cmake --build build --target ggml_package
+      run: |
+        cmake --build build --target ggml_package
+        mkdir -p release
+        cp build/ggml-src.zip release/
 
     - name: Create Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: build/ggml-src.zip
-        draft: false
-        prerelease: false
+      id: create_release
+      uses: ggml-org/action-create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+    - name: Upload release
+      id: upload_release
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          const path = require('path');
+          const fs = require('fs');
+          const release_id = '${{ steps.create_release.outputs.id }}';
+          for (let file of await fs.readdirSync('./release')) {
+              if (path.extname(file) === '.zip') {
+                console.log('uploadReleaseAsset', file);
+                await github.repos.uploadReleaseAsset({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  release_id: release_id,
+                  name: file,
+                  data: await fs.readFileSync(`./release/${file}`)
+                });
+              }
+            }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,3 +447,11 @@ if (MSVC)
         disable_msvc_warnings(test-pool)
     endif ()
 endif()
+
+## Target ggml_package to create a zip file with the source code.
+set(package_files include/ src/ CMakeLists.txt cmake LICENSE)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-src.zip
+    COMMAND ${CMAKE_COMMAND} -E tar c ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-src.zip --format=zip -- ${package_files}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS ${package_files})
+add_custom_target(${PROJECT_NAME}_package DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-src.zip)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,11 +447,3 @@ if (MSVC)
         disable_msvc_warnings(test-pool)
     endif ()
 endif()
-
-## Target ggml_package to create a zip file with the source code.
-set(package_files include/ src/ CMakeLists.txt cmake LICENSE)
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-src.zip
-    COMMAND ${CMAKE_COMMAND} -E tar c ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-src.zip --format=zip -- ${package_files}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    DEPENDS ${package_files})
-add_custom_target(${PROJECT_NAME}_package DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-src.zip)


### PR DESCRIPTION
This commit adds a GitHub Actions workflow to automate the release process. Currently this will only create an archive of the sources for ggml when a tag is pushed.

The motivation for this is that when we start releasing versions of ggml using semantic versioning it can be nice to have the sources needed for ggml to be deployed as a github release. This enables CMake users that use `FetchContent` efficiently specify the the zip file instead of cloning, and the zip file will only contain the files needed and not all the source files which is the case with the "Source Code (zip)" that is automatically created by the release job.

Example usage with `FetchContent`:
```cmake
cmake_minimum_required(VERSION 3.14)
project(ggml_example)

set(CMAKE_CXX_STANDARD 17)

include(FetchContent)
FetchContent_Declare(ggml
    URL https://github.com/danbev/ggml/releases/download/v0.1.1-test/ggml-src.zip
    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
)

FetchContent_MakeAvailable(ggml)

add_executable(ggml_example main.cpp)
target_link_libraries(ggml_example ggml)
```
And with the following `main.cpp` file:
```c++
 #include <iostream>
 #include <ggml.h>

 int main() {
     std::cout << "GGML Version: " << ggml_version() << std::endl;
     return 0;
 }
```
This could then be built using:
```console
$ cmake -S . -B build
$ cmake --build build
$ ./build/ggml_example
GGML Version: 0.0.2472
```

An example release can be found here:
https://github.com/danbev/ggml/releases/tag/v0.1.1-test

Refs: https://github.com/ggml-org/ggml/issues/1333

----
*For changes to the core `ggml` library (including to the CMake build system), please open a PR in https://github.com/ggml-org/llama.cpp. Doing so will make your PR more visible, better tested and more likely to be reviewed.*

I'm not ignoring this notice, it was just easier to try this out on my fork as it involved CI as opposed going via llama.cpp. 

