### PR TITLE
Update gguf specification (the `ggml_types` enum)

### DIFF
--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -161,7 +161,17 @@ enum ggml_type: uint32_t {
     GGML_TYPE_I64     = 27,
     GGML_TYPE_F64     = 28,
     GGML_TYPE_IQ1_M   = 29,
-    GGML_TYPE_COUNT,
+    GGML_TYPE_BF16    = 30,
+    // GGML_TYPE_Q4_0_4_4 = 31, support has been removed from gguf files
+    // GGML_TYPE_Q4_0_4_8 = 32,
+    // GGML_TYPE_Q4_0_8_8 = 33,
+    GGML_TYPE_TQ1_0   = 34,
+    GGML_TYPE_TQ2_0   = 35,
+    // GGML_TYPE_IQ4_NL_4_4 = 36,
+    // GGML_TYPE_IQ4_NL_4_8 = 37,
+    // GGML_TYPE_IQ4_NL_8_8 = 38,
+    GGML_TYPE_MXFP4   = 39, // MXFP4 (1 block)
+    GGML_TYPE_COUNT   = 40,
 };
 
 enum gguf_metadata_value_type: uint32_t {


### PR DESCRIPTION
The `gguf_types` enum shown in the specification was not up to date with the actual implementation:

BF16, TQ1_0,TQ2_0 and MXFP4 were missing in the enum declaration in the spec.