### PR TITLE
scripts : fix sed usage to work on Mac

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -154,10 +154,10 @@ if [ "$DRY_RUN" = true ]; then
     echo "  [dry-run] Would update GGML_VERSION_PATCH to $NEW_PATCH"
     echo "  [dry-run] Would remove -dev suffix"
 else
-    sed -i "s/set(GGML_VERSION_MAJOR [0-9]*)/set(GGML_VERSION_MAJOR $NEW_MAJOR)/" CMakeLists.txt
-    sed -i "s/set(GGML_VERSION_MINOR [0-9]*)/set(GGML_VERSION_MINOR $NEW_MINOR)/" CMakeLists.txt
-    sed -i "s/set(GGML_VERSION_PATCH [0-9]*)/set(GGML_VERSION_PATCH $NEW_PATCH)/" CMakeLists.txt
-    sed -i 's/set(GGML_VERSION_DEV "-dev")/set(GGML_VERSION_DEV "")/' CMakeLists.txt
+    sed -i'' -e "s/set(GGML_VERSION_MAJOR [0-9]*)/set(GGML_VERSION_MAJOR $NEW_MAJOR)/" CMakeLists.txt
+    sed -i'' -e "s/set(GGML_VERSION_MINOR [0-9]*)/set(GGML_VERSION_MINOR $NEW_MINOR)/" CMakeLists.txt
+    sed -i'' -e "s/set(GGML_VERSION_PATCH [0-9]*)/set(GGML_VERSION_PATCH $NEW_PATCH)/" CMakeLists.txt
+    sed -i'' -e 's/set(GGML_VERSION_DEV "-dev")/set(GGML_VERSION_DEV "")/' CMakeLists.txt
 fi
 echo ""
 
@@ -190,7 +190,7 @@ case $VERSION_TYPE in
         if [ "$DRY_RUN" = true ]; then
             echo "  [dry-run] Would update GGML_VERSION_MINOR to $NEXT_DEV_MINOR"
         else
-            sed -i "s/set(GGML_VERSION_MINOR [0-9]*)/set(GGML_VERSION_MINOR $NEXT_DEV_MINOR)/" CMakeLists.txt
+            sed -i'' -e "s/set(GGML_VERSION_MINOR [0-9]*)/set(GGML_VERSION_MINOR $NEXT_DEV_MINOR)/" CMakeLists.txt
         fi
         ;;
     patch)
@@ -199,7 +199,7 @@ case $VERSION_TYPE in
         if [ "$DRY_RUN" = true ]; then
             echo "  [dry-run] Would update GGML_VERSION_PATCH to $NEXT_DEV_PATCH"
         else
-            sed -i "s/set(GGML_VERSION_PATCH [0-9]*)/set(GGML_VERSION_PATCH $NEXT_DEV_PATCH)/" CMakeLists.txt
+            sed -i'' -e "s/set(GGML_VERSION_PATCH [0-9]*)/set(GGML_VERSION_PATCH $NEXT_DEV_PATCH)/" CMakeLists.txt
         fi
         ;;
 esac
@@ -207,7 +207,7 @@ esac
 if [ "$DRY_RUN" = true ]; then
     echo "  [dry-run] Would add -dev suffix back"
 else
-    sed -i 's/set(GGML_VERSION_DEV "")/set(GGML_VERSION_DEV "-dev")/' CMakeLists.txt
+    sed -i'' -e 's/set(GGML_VERSION_DEV "")/set(GGML_VERSION_DEV "-dev")/' CMakeLists.txt
 fi
 echo ""
 


### PR DESCRIPTION
On `master` I get this error when running the `scripts/release.sh` on Mac:

```bash
./scripts/release.sh patch
Starting automated release process...
Checking if local master is up-to-date with remote...
From https://github.com/ggml-org/ggml
 * branch              master     -> FETCH_HEAD
✓ Local master is up-to-date with remote
Step 1: Reading current version...
Current version: 0.9.0-dev
New release version: 0.9.1
Release candidate branch: ggml-rc-v0.9.1
Step 2: Creating release candidate branch...
Switched to a new branch 'ggml-rc-v0.9.1'
✓ Created and switched to branch: ggml-rc-v0.9.1
Step 3: Updating version in CMakeLists.txt...
sed: 1: "CMakeLists.txt": invalid command code C
```

According to https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux, this PR should fix it.