### PR TITLE
fix typo mismatch in gpt

### DIFF
--- a/examples/gpt-2/main-alloc.cpp
+++ b/examples/gpt-2/main-alloc.cpp
@@ -60,8 +60,8 @@ struct gpt2_model {
     struct ggml_tensor * ln_f_g;
     struct ggml_tensor * ln_f_b;
 
-    struct ggml_tensor * wte;     // position embedding
-    struct ggml_tensor * wpe;     //    token embedding
+    struct ggml_tensor * wte;     //    token embedding
+    struct ggml_tensor * wpe;     // position embedding
     struct ggml_tensor * lm_head; // language model head
 
     std::vector<gpt2_layer> layers;

--- a/examples/gpt-2/main-backend.cpp
+++ b/examples/gpt-2/main-backend.cpp
@@ -77,8 +77,8 @@ struct gpt2_model {
     struct ggml_tensor * ln_f_g;
     struct ggml_tensor * ln_f_b;
 
-    struct ggml_tensor * wte;     // position embedding
-    struct ggml_tensor * wpe;     //    token embedding
+    struct ggml_tensor * wte;     //    token embedding
+    struct ggml_tensor * wpe;     // position embedding
     struct ggml_tensor * lm_head; // language model head
 
     std::vector<gpt2_layer> layers;

--- a/examples/gpt-2/main-batched.cpp
+++ b/examples/gpt-2/main-batched.cpp
@@ -109,8 +109,8 @@ struct gpt2_model {
     struct ggml_tensor * ln_f_g;
     struct ggml_tensor * ln_f_b;
 
-    struct ggml_tensor * wte;     // position embedding
-    struct ggml_tensor * wpe;     //    token embedding
+    struct ggml_tensor * wte;     //    token embedding
+    struct ggml_tensor * wpe;     // position embedding
     struct ggml_tensor * lm_head; // language model head
 
     std::vector<gpt2_layer> layers;

--- a/examples/gpt-2/main-ctx.cpp
+++ b/examples/gpt-2/main-ctx.cpp
@@ -57,8 +57,8 @@ struct gpt2_model {
     struct ggml_tensor * ln_f_g;
     struct ggml_tensor * ln_f_b;
 
-    struct ggml_tensor * wte;     // position embedding
-    struct ggml_tensor * wpe;     //    token embedding
+    struct ggml_tensor * wte;     //    token embedding
+    struct ggml_tensor * wpe;     // position embedding
     struct ggml_tensor * lm_head; // language model head
 
     std::vector<gpt2_layer> layers;

--- a/examples/gpt-2/main-sched.cpp
+++ b/examples/gpt-2/main-sched.cpp
@@ -81,8 +81,8 @@ struct gpt2_model {
     struct ggml_tensor * ln_f_g;
     struct ggml_tensor * ln_f_b;
 
-    struct ggml_tensor * wte;     // position embedding
-    struct ggml_tensor * wpe;     //    token embedding
+    struct ggml_tensor * wte;     //    tkoen embedding
+    struct ggml_tensor * wpe;     // position embedding
     struct ggml_tensor * lm_head; // language model head
 
     std::vector<gpt2_layer> layers;

--- a/examples/gpt-j/main.cpp
+++ b/examples/gpt-j/main.cpp
@@ -57,7 +57,7 @@ struct gptj_model {
     struct ggml_tensor * ln_f_g;
     struct ggml_tensor * ln_f_b;
 
-    struct ggml_tensor * wte; // position embedding
+    struct ggml_tensor * wte; // token embedding
 
     struct ggml_tensor * lmh_g; // language model head
     struct ggml_tensor * lmh_b; // language model bias


### PR DESCRIPTION
This PR aims to fix the comment/typo mismatch in `examples/gpt-2` and `examples/gpt-j`. In `gpt2_model` struct, the `wte` member variable is commented as position embedding, but it should be token embedding if checking its name and usage.