### PR TITLE
fix sam example time init func miss

### DIFF
--- a/examples/sam/sam.cpp
+++ b/examples/sam/sam.cpp
@@ -2230,6 +2230,7 @@ bool sam_params_parse(int argc, char ** argv, sam_params & params) {
 
 
 int main(int argc, char ** argv) {
+    ggml_time_init();
     const int64_t t_main_start_us = ggml_time_us();
 
     sam_params params;


### PR DESCRIPTION
In SAM example, ggml_time_init is not been called before ggml_time_us. Now, just add the init function.