### PR TITLE
requirements: sync requirements.txt with llama.cpp versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ torchvision~=0.21.0
 transformers==5.5.1
 gguf>=0.1.0
 keras==3.5.0
-tensorflow==2.18.0
+tensorflow==2.20.0
 
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch~=2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 accelerate==0.19.0
-numpy~=1.26.4
+numpy~=1.26.4; python_version < "3.13"
+numpy~=2.1.0; python_version >= "3.13"
 sentencepiece>=0.1.98,<0.3.0
 torchvision~=0.21.0
 transformers==5.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 accelerate==0.19.0
-numpy>=2.0.2
-sentencepiece~=0.1.98
-torchvision>=0.15.2
-transformers>=4.35.2,<5.0.0
+numpy~=1.26.4
+sentencepiece>=0.1.98,<0.3.0
+torchvision~=0.21.0
+transformers==5.5.1
 gguf>=0.1.0
 keras==3.5.0
 tensorflow==2.18.0
 
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch~=2.5.1
+torch~=2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sentencepiece>=0.1.98,<0.3.0
 torchvision~=0.21.0
 transformers==5.5.1
 gguf>=0.1.0
-keras==3.5.0
+keras==3.10.0
 tensorflow==2.20.0
 
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
ref: https://github.com/ggml-org/ggml/pull/1476#issuecomment-4378332120

This PR fixes the CI error referenced above and attempts to match the package dependency requirements with llama.cpp to ensure consistency. Also applies supply-chain hardening, the same that was done in llama.cpp.

Tested to be working on sg-hl1-ci-nvidia-vulkan-cm runner (where the `pip install -r` failed @ Python 3.13. Not sure what to test in this repository so please advise if needed.

cc: @ggerganov 