### PR TITLE
docs : add MTP to GGUF Type slot

### DIFF
--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -44,6 +44,7 @@ The components are:
   - If missing, then file is by default a typical gguf tensor model file
   - `LoRA` : GGUF file is a LoRA adapter
   - `vocab` : GGUF file with only vocab data and metadata
+  - `MTP` : GGUF file contains Multi-Token Prediction heads (a speculative-decoding draft module), intended to be loaded alongside a base model of matching architecture and version
 1. **Shard**: (Optional) Indicates and denotes that the model has been split into multiple shards, formatted as `<ShardNum>-of-<ShardTotal>`.
     - *ShardNum* : Shard position in this model. Must be 5 digits padded by zeros.
       - Shard number always starts from `00001` onwards (e.g. First shard always starts at `00001-of-XXXXX` rather than `00000-of-XXXXX`).
@@ -54,7 +55,7 @@ The components are:
 
 At a minimum all model files should have at least BaseName, SizeLabel, Version, in order to be easily validated as a file that is keeping with the GGUF Naming Convention. An example of this issue is that it is easy for Encoding to be mistaken as a FineTune if Version is omitted.
 
-To validate you can use this regular expression `^(?<BaseName>[A-Za-z0-9\s]*(?:(?:-(?:(?:[A-Za-z\s][A-Za-z0-9\s]*)|(?:[0-9\s]*)))*))-(?:(?<SizeLabel>(?:\d+x)?(?:\d+\.)?\d+[A-Za-z](?:-[A-Za-z]+(\d+\.)?\d+[A-Za-z]+)?)(?:-(?<FineTune>[A-Za-z0-9\s-]+))?)?-(?:(?<Version>v\d+(?:\.\d+)*))(?:-(?<Encoding>(?!LoRA|vocab)[\w_]+))?(?:-(?<Type>LoRA|vocab))?(?:-(?<Shard>\d{5}-of-\d{5}))?\.gguf$` which will check that you got the minimum BaseName, SizeLabel and Version present in the correct order.
+To validate you can use this regular expression `^(?<BaseName>[A-Za-z0-9\s]*(?:(?:-(?:(?:[A-Za-z\s][A-Za-z0-9\s]*)|(?:[0-9\s]*)))*))-(?:(?<SizeLabel>(?:\d+x)?(?:\d+\.)?\d+[A-Za-z](?:-[A-Za-z]+(\d+\.)?\d+[A-Za-z]+)?)(?:-(?<FineTune>[A-Za-z0-9\s-]+))?)?-(?:(?<Version>v\d+(?:\.\d+)*))(?:-(?<Encoding>(?!LoRA|vocab|MTP)[\w_]+))?(?:-(?<Type>LoRA|vocab|MTP))?(?:-(?<Shard>\d{5}-of-\d{5}))?\.gguf$` which will check that you got the minimum BaseName, SizeLabel and Version present in the correct order.
 
 For example:
 
@@ -81,12 +82,20 @@ For example:
     - Weight Encoding Scheme: Q4_0
     - Shard: 3 out of 9 total shards
 
+  * `Qwen3-27B-v1.0-Q4_K_M-MTP.gguf`
+    - Model Name: Qwen3
+    - Expert Count: 0
+    - Parameter Count: 27B
+    - Version Number: v1.0
+    - Weight Encoding Scheme: Q4_K_M
+    - Type: MTP (Multi-Token Prediction draft module)
+
 
 <details><summary>Example Node.js Regex Function</summary>
 
 ```js
 #!/usr/bin/env node
-const ggufRegex = /^(?<BaseName>[A-Za-z0-9\s]*(?:(?:-(?:(?:[A-Za-z\s][A-Za-z0-9\s]*)|(?:[0-9\s]*)))*))-(?:(?<SizeLabel>(?:\d+x)?(?:\d+\.)?\d+[A-Za-z](?:-[A-Za-z]+(\d+\.)?\d+[A-Za-z]+)?)(?:-(?<FineTune>[A-Za-z0-9\s-]+))?)?-(?:(?<Version>v\d+(?:\.\d+)*))(?:-(?<Encoding>(?!LoRA|vocab)[\w_]+))?(?:-(?<Type>LoRA|vocab))?(?:-(?<Shard>\d{5}-of-\d{5}))?\.gguf$/;
+const ggufRegex = /^(?<BaseName>[A-Za-z0-9\s]*(?:(?:-(?:(?:[A-Za-z\s][A-Za-z0-9\s]*)|(?:[0-9\s]*)))*))-(?:(?<SizeLabel>(?:\d+x)?(?:\d+\.)?\d+[A-Za-z](?:-[A-Za-z]+(\d+\.)?\d+[A-Za-z]+)?)(?:-(?<FineTune>[A-Za-z0-9\s-]+))?)?-(?:(?<Version>v\d+(?:\.\d+)*))(?:-(?<Encoding>(?!LoRA|vocab|MTP)[\w_]+))?(?:-(?<Type>LoRA|vocab|MTP))?(?:-(?<Shard>\d{5}-of-\d{5}))?\.gguf$/;
 
 function parseGGUFFilename(filename) {
   const match = ggufRegex.exec(filename);
@@ -101,6 +110,7 @@ const testCases = [
   {filename: 'Grok-100B-v1.0-Q4_0-00003-of-00009.gguf',            expected: { BaseName: 'Grok',                 SizeLabel: '100B',     FineTune: null, Version: 'v1.0',   Encoding: 'Q4_0', Type: null, Shard: "00003-of-00009"}},
   {filename: 'Hermes-2-Pro-Llama-3-8B-v1.0-F16.gguf',              expected: { BaseName: 'Hermes-2-Pro-Llama-3', SizeLabel: '8B', FineTune: null, Version: 'v1.0',   Encoding: 'F16',  Type: null, Shard: null}},
   {filename: 'Phi-3-mini-3.8B-ContextLength4k-instruct-v1.0.gguf', expected: { BaseName: 'Phi-3-mini',   SizeLabel: '3.8B-ContextLength4k', FineTune: 'instruct', Version: 'v1.0',   Encoding: null,  Type: null, Shard: null}},
+  {filename: 'Qwen3-27B-v1.0-Q4_K_M-MTP.gguf',                     expected: { BaseName: 'Qwen3',                SizeLabel: '27B',      FineTune: null, Version: 'v1.0',   Encoding: 'Q4_K_M', Type: 'MTP', Shard: null}},
   {filename: 'not-a-known-arrangement.gguf',                       expected: null},
 ];
 
@@ -116,6 +126,14 @@ testCases.forEach(({ filename, expected }) => {
 ```
 
 </details>
+
+
+#### Note on community variants (non-normative)
+
+Some publishers use filename markers that are **not** part of this spec. Tooling should not depend on them:
+
+- **imatrix calibration.** `IQ*` quants do not imply that imatrix calibration was used during quantization. Some publishers prefix the `Encoding` with `i1-` (e.g. `DeepSeek-V3-v1.0-i1-IQ4_XS.gguf`) to mark imatrix-calibrated files; others ship a sidecar `imatrix*.dat` and leave the filename unchanged. Calibration provenance should be carried in GGUF metadata, not inferred from the filename.
+- **MTP placement.** Early MTP releases have placed the `MTP` marker between `BaseName`/`SizeLabel` and `Encoding` (e.g. `Qwen3-27B-MTP-Q4_K_M.gguf`). The canonical position defined by this spec is the `Type` slot, after `Encoding`.
 
 
 ### File Structure

--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -128,11 +128,6 @@ testCases.forEach(({ filename, expected }) => {
 </details>
 
 
-#### Note on MTP filename position (non-normative)
-
-Some early MTP releases place the `MTP` marker between `BaseName`/`SizeLabel` and `Encoding` (e.g. `Qwen3-27B-MTP-Q4_K_M.gguf`). The canonical position defined by this spec is the `Type` slot, after `Encoding`. Tooling should not depend on the pre-`Encoding` placement.
-
-
 ### File Structure
 
 ![image](https://github.com/ggerganov/ggml/assets/1991296/c3623641-3a1d-408e-bfaf-1b7c4e16aa63)

--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -128,12 +128,9 @@ testCases.forEach(({ filename, expected }) => {
 </details>
 
 
-#### Note on community variants (non-normative)
+#### Note on MTP filename position (non-normative)
 
-Some publishers use filename markers that are **not** part of this spec. Tooling should not depend on them:
-
-- **imatrix calibration.** `IQ*` quants do not imply that imatrix calibration was used during quantization. Some publishers prefix the `Encoding` with `i1-` (e.g. `DeepSeek-V3-v1.0-i1-IQ4_XS.gguf`) to mark imatrix-calibrated files; others ship a sidecar `imatrix*.dat` and leave the filename unchanged. Calibration provenance should be carried in GGUF metadata, not inferred from the filename.
-- **MTP placement.** Early MTP releases have placed the `MTP` marker between `BaseName`/`SizeLabel` and `Encoding` (e.g. `Qwen3-27B-MTP-Q4_K_M.gguf`). The canonical position defined by this spec is the `Type` slot, after `Encoding`.
+Some early MTP releases place the `MTP` marker between `BaseName`/`SizeLabel` and `Encoding` (e.g. `Qwen3-27B-MTP-Q4_K_M.gguf`). The canonical position defined by this spec is the `Type` slot, after `Encoding`. Tooling should not depend on the pre-`Encoding` placement.
 
 
 ### File Structure


### PR DESCRIPTION
Adds `MTP` as a third value for the `Type` slot (alongside `LoRA` and `vocab`) to cover Multi-Token Prediction / speculative-decoding draft modules shipped beside a base model. Updates the regex in both spots and adds an example + test case.

@ggerganov previously OK'd adding `MTP`.

**Open question:** the spec puts `Type` after `Encoding`, so the canonical form here is `…-Q4_K_M-MTP.gguf`. Some community releases place `MTP` before the encoding (`…-MTP-Q4_K_M.gguf`). Happy to flip if you'd rather match current filenames.