### PR TITLE
ggml-alloc: fix out-of-bounds read in ggml_dyn_tallocr_remove_block

### DIFF
--- a/src/ggml-alloc.c
+++ b/src/ggml-alloc.c
@@ -150,7 +150,7 @@ static void ggml_dyn_tallocr_insert_block(struct tallocr_chunk * chunk, size_t o
 
 static void ggml_dyn_tallocr_remove_block(struct tallocr_chunk * chunk, int idx) {
     // shift all elements after idx by 1 to the left, overwriting the element at idx
-    for (int i = idx; i < chunk->n_free_blocks; i++) {
+    for (int i = idx; i < chunk->n_free_blocks - 1; i++) {
         chunk->free_blocks[i] = chunk->free_blocks[i+1];
     }
     chunk->n_free_blocks--;


### PR DESCRIPTION
In `ggml_dyn_tallocr_remove_block`, the loop that shifts free blocks
left after a removal iterated one step too far:

    for (int i = idx; i < chunk->n_free_blocks; i++) {
        chunk->free_blocks[i] = chunk->free_blocks[i+1];
    }

On the final iteration, `i` equals `chunk->n_free_blocks - 1` (the last
valid index), causing `chunk->free_blocks[i+1]` to read one slot past
the end of the live array. This is undefined behavior and is caught by
ASan/UBSan. The stale value written does not corrupt visible state since
`n_free_blocks--` immediately follows, but the read itself is illegal.

Fix: change the loop bound to `i < chunk->n_free_blocks - 1`, stopping
one iteration early. The last element no longer needs to be overwritten
since it falls outside the live range after the decrement.

This path is exercised on every tensor deallocation during graph
planning, triggered from both `ggml_dyn_tallocr_alloc` (when a block is
fully consumed) and `ggml_dyn_tallocr_free_bytes` (when merging adjacent
free blocks).