### PR TITLE
ggml.h: correct ggml_silu_back arg docstring

### DIFF
--- a/include/ggml.h
+++ b/include/ggml.h
@@ -1189,8 +1189,8 @@ extern "C" {
             struct ggml_context * ctx,
             struct ggml_tensor  * a);
 
-    // a - x
-    // b - dy
+    // a - dy
+    // b - x
     GGML_API struct ggml_tensor * ggml_silu_back(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,


### PR DESCRIPTION
Header comment for ggml_silu_back says `a - x; b - dy` but the implementation reads `src[0]` as dy and `src[1]` as x.

See `src/ggml-cpu/ops.cpp` around the silu_back forward: `grad = dst->src[0]` is passed as the `dy` argument to `ggml_vec_silu_backward_f32(n, dx, x, dy)`, and `src1 = dst->src[1]` is passed as `x`. So the actual arg semantics are `a = dy`, `b = x`.

Trivial docstring fix; no behavior change.