### PR TITLE
Fix build and test running for Windows MSVC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -487,7 +487,9 @@ endforeach()
 
 target_link_libraries(ggml-base PRIVATE Threads::Threads)
 
-if (DEFINED MATH_LIBRARY)
+# Use truthy check instead of DEFINED: on Windows find_library(m) sets MATH_LIBRARY to
+# MATH_LIBRARY-NOTFOUND, which is DEFINED but not a valid library to link.
+if (MATH_LIBRARY)
     target_link_libraries(ggml-base PRIVATE ${MATH_LIBRARY})
 elseif (NOT WIN32 AND NOT DEFINED ENV{ONEAPI_ROOT})
     target_link_libraries(ggml-base PRIVATE m)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -165,6 +165,9 @@ add_definitions(-UNDEBUG)
 set(TEST_TARGET test-backend-ops)
 add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
 target_link_libraries(${TEST_TARGET} PRIVATE ggml Threads::Threads)
+if (MSVC)
+    target_link_options(${TEST_TARGET} PRIVATE "/STACK:8388608") # 8MB
+endif()
 add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
 set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")
 


### PR DESCRIPTION
1. set stack-size to 8MB, to fix stack-overflow.
2. solve `MATH_LIBRARY-NOTFOUND` in config.

*For changes to the core `ggml` library (including to the CMake build system), please open a PR in https://github.com/ggml-org/llama.cpp. Doing so will make your PR more visible, better tested and more likely to be reviewed.*
