### PR TITLE
security: harden GGUF parser against memory exhaustion DoS

### DIFF
--- a/src/gguf.cpp
+++ b/src/gguf.cpp
@@ -15,8 +15,11 @@
 #include <string>
 #include <vector>
 
-#define GGUF_MAX_STRING_LENGTH  (1024*1024*1024)
-#define GGUF_MAX_ARRAY_ELEMENTS (1024*1024*1024)
+// Security: reduced from 1 GiB to 64 MiB to prevent memory exhaustion DoS
+// via crafted GGUF files with oversized string or array metadata.
+// 64 MiB is still far above any legitimate model metadata size.
+#define GGUF_MAX_STRING_LENGTH  (64*1024*1024)
+#define GGUF_MAX_ARRAY_ELEMENTS (64*1024*1024)
 
 #ifdef _WIN32
 #    define gguf_ftell _ftelli64
@@ -609,8 +612,19 @@ static struct gguf_context * gguf_init_from_reader(const struct gguf_reader & gr
         const int alignment_idx = gguf_find_key(ctx, GGUF_KEY_GENERAL_ALIGNMENT);
         ctx->alignment = alignment_idx == -1 ? GGUF_DEFAULT_ALIGNMENT : gguf_get_val_u32(ctx, alignment_idx);
 
+        // Security: alignment must be a power of 2 AND within a sane range.
+        // Without an upper bound, a malicious file could set alignment to e.g. 2^31,
+        // causing massive padding between tensors and triggering OOM during loading.
+        // 1 MiB (1<<20) is well above any legitimate alignment (typically 32-4096 bytes).
+        static const size_t GGUF_MAX_ALIGNMENT = 1 << 20; // 1 MiB
+
         if (ctx->alignment == 0 || (ctx->alignment & (ctx->alignment - 1)) != 0) {
             GGML_LOG_ERROR("%s: alignment %zu is not a power of 2\n", __func__, ctx->alignment);
+            gguf_free(ctx);
+            return nullptr;
+        }
+        if (ctx->alignment > GGUF_MAX_ALIGNMENT) {
+            GGML_LOG_ERROR("%s: alignment %zu exceeds maximum allowed %zu\n", __func__, ctx->alignment, GGUF_MAX_ALIGNMENT);
             gguf_free(ctx);
             return nullptr;
         }


### PR DESCRIPTION
## Summary

The GGUF parser has two resource exhaustion vulnerabilities that allow a crafted GGUF file (as small as ~160 bytes) to trigger multi-gigabyte memory allocations and crash any application that loads it.

## Vulnerabilities

### 1. Excessive MAX limits for string/array metadata (DoS)

`GGUF_MAX_STRING_LENGTH` and `GGUF_MAX_ARRAY_ELEMENTS` are both set to **1 GiB** (`1024*1024*1024`). A malicious GGUF file can declare a single KV string of length ~1 GiB, forcing the parser to attempt a ~1 GiB allocation before any data is actually read. On systems with limited memory, this causes immediate OOM.

**Fix:** Reduced both limits from 1 GiB to 64 MiB. This is still far above any legitimate model metadata size (typical metadata is < 1 MiB) while preventing trivial DoS.

### 2. Missing upper bound for `general.alignment` (DoS / potential overflow)

The `general.alignment` KV value is validated as a power of 2, but has **no upper bound**. A malicious file can set alignment to `2^30` (1 GiB), causing:
- Massive padding between every tensor (`GGML_PAD(tensor_size, 1GiB)`)
- Total data section size overflow or multi-GiB allocation from a tiny file
- On 32-bit systems, the alignment value can cause integer overflow in padding calculations

**Fix:** Added an upper bound of 1 MiB (`1 << 20`) for alignment. This is well above any real alignment requirement (typically 32-4096 bytes for SIMD/GPU memory alignment).

## Impact

- **Attack vector:** User loads a crafted GGUF model file (e.g., downloaded from a model hub)
- **Effect:** Application OOM crash (Denial of Service)
- **Affected code:** `gguf_init_from_reader()` in `src/gguf.cpp`
- **File size:** A malicious GGUF file triggering this can be as small as ~160 bytes

## Changes

- `src/gguf.cpp`: Reduced `GGUF_MAX_STRING_LENGTH` and `GGUF_MAX_ARRAY_ELEMENTS` from 1 GiB to 64 MiB
- `src/gguf.cpp`: Added `GGUF_MAX_ALIGNMENT` (1 MiB) upper bound check after the existing power-of-2 validation

## Related

- Reported via [huntr.com](https://huntr.com)
- Related but distinct from CVE-2026-33298 (integer overflow in `ggml_nbytes`, fixed in b7824)

CC: @ggerganov @JohannesGaessler
