### PR TITLE
tests : add OLMoE-sized K-quant shapes to test_mul_mat_id (ref #1506)

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9033,6 +9033,16 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 2, false, 64, 16, 3*ggml_blck_size(type_a)));
     }
 
+    // K-quant coverage at a production MoE topology. The cases above top out at
+    // n_mats=8, m=512, k=256; OLMoE-1B-7B uses 64 experts with top-8 routing,
+    // gate_proj/up_proj out=1024 in=2048 and down_proj out=2048 in=1024.
+    for (ggml_type type_a : {GGML_TYPE_Q2_K, GGML_TYPE_Q3_K, GGML_TYPE_Q4_K, GGML_TYPE_Q5_K, GGML_TYPE_Q6_K}) {
+        for (int n : {1, 32}) {
+            test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 64, 8, false, 1024, n, 2048));
+            test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 64, 8, false, 2048, n, 1024));
+        }
+    }
+
     for (ggml_type type_a : base_types) {
         for (ggml_type type_b : {GGML_TYPE_F32 /*, GGML_TYPE_F16 */}) {
             for (int n_mats : {4, 8}) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9733,6 +9733,16 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 4, false, 16, 10, 256));
     }
 
+    // K-quant coverage at a production MoE topology. The cases above top out at
+    // n_mats=8, m=512, k=256; OLMoE-1B-7B uses 64 experts with top-8 routing,
+    // gate_proj/up_proj out=1024 in=2048 and down_proj out=2048 in=1024.
+    for (ggml_type type_a : {GGML_TYPE_Q2_K, GGML_TYPE_Q3_K, GGML_TYPE_Q4_K, GGML_TYPE_Q5_K, GGML_TYPE_Q6_K}) {
+        for (int n : {1, 32}) {
+            test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 64, 8, false, 1024, n, 2048));
+            test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 64, 8, false, 2048, n, 1024));
+        }
+    }
+
     for (ggml_type type_a : base_types) {
         for (ggml_type type_b : {GGML_TYPE_F32 /*, GGML_TYPE_F16 */}) {
             for (int n_mats : {4, 8}) {


### PR DESCRIPTION
The existing `test_mul_mat_id` matrix tops out at `m=512, k=256` with `n_mats in {4,8}, n_used in {1,2,4}`. Production MoE models use much larger shapes - OLMoE-1B-7B is 64 experts with top-8 routing (`gate/up` projection `out=1024 in=2048`, `down` projection `out=2048 in=1024`).

This adds that topology as preventive regression coverage: `Q2_K, Q3_K, Q4_K, Q5_K, Q6_K` at `n in {1, 32}` for both projection shapes, 20 cases total.

All 20 pass on current master. Verified on an M1 Pro with a Release build: a CPU-only run gives 885/885 MUL_MAT_ID cases passed, and a Metal build passes 3/3 backends with zero failures.

Context: this started as coverage for #1506, which reported `mul_mat_id` corruption with K-quants at OLMoE shape. That issue has since been closed - the op-level isolation showed `mul_mat_id` was correct on master, and the reporter traced the corruption to their own loader. So there is no bug to fix here. The value is that the shapes real MoE models actually use were not covered before, and a future regression at MoE scale would now show up in CI.
