### PR TITLE
ggml : assert b->ne[3] == 1 in ggml_conv_transpose_2d_p0 (#1448)

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -4947,6 +4947,12 @@ struct ggml_tensor * ggml_conv_transpose_2d_p0(
         struct ggml_tensor  * b,
         int                   stride) {
     GGML_ASSERT(a->ne[3] == b->ne[2]);
+    // The CPU/Metal/Vulkan compute kernels currently only iterate batch index 0,
+    // so calling with b->ne[3] > 1 would silently produce zeros for batches 1..N
+    // while reporting the correct 4D output shape. Reject at the API level —
+    // matches the GGML_ASSERT(a->ne[3] == 1) precedent in ggml_conv_transpose_1d.
+    // See: https://github.com/ggml-org/ggml/issues/1448
+    GGML_ASSERT(b->ne[3] == 1);
 
     const int64_t ne[4] = {
         ggml_calc_conv_transpose_output_size(b->ne[0], a->ne[0], stride, 0 /*p0*/),


### PR DESCRIPTION
Addresses #1448 via Option A from @janblumenkamp's analysis (assert at the API level, no kernel changes).

### Bug

`ggml_conv_transpose_2d_p0` accepts inputs with `b->ne[3] > 1` and returns a tensor with the correct 4D output shape, but the CPU compute kernel (`ggml_compute_forward_conv_transpose_2d_impl` in `ggml-cpu/ops.cpp`) only iterates batch index 0:

- the `src1` permutation loop iterates `ne12, ne11, ne10` but never `ne13`;
- the compute loop offsets the output by `i2*nb2` (channel) only, not by `i3*nb3` (batch);
- the work-buffer sizing omits a `*ne13` factor.

Net effect: batch 0 is correct, batches 1..N-1 are silently zero. Caught only by explicitly comparing across batch elements. The bug has been present since 8da5be2c (Aug 2023). Every existing caller (SAM example, `test-conv-transpose.c`, `test-backend-ops.cpp` parameterizations) uses `ne[3] == 1`, so it has never surfaced in CI.

### Fix

Add `GGML_ASSERT(b->ne[3] == 1)` to `ggml_conv_transpose_2d_p0`. Matches the existing `GGML_ASSERT(a->ne[3] == 1)` precedent in `ggml_conv_transpose_1d`. Turns silent data corruption into an immediate, debuggable abort.

### Why not implement batch support instead?

Option B (implementing the batch loop in CPU + Metal + Vulkan kernels) is genuinely useful but adds capability for a code path with no current caller. Option A solves the correctness problem and matches existing precedent with minimal risk. If a caller later needs batched `conv_transpose_2d_p0`, removing the assert and implementing batch support across backends is a clean follow-up.

### Verification

- Reporter's reproducer (#1448 body, 3-batch input with identity-like kernel). Before this change it prints `batch 1: sum_abs = 0.0 <-- BUG`. After this change: aborts with `GGML_ASSERT(b->ne[3] == 1) failed` at `ggml.c:4882`.
- Full `test-backend-ops test` (Metal + CPU): no regressions. All `CONV_TRANSPOSE_2D` parameterizations use `ne[3] == 1` and continue to pass.

### No test added

The natural regression test ("assert fires on `ne[3] > 1`") requires a death-test pattern (fork + check exit on SIGABRT) since `GGML_ASSERT` aborts the process. `test-backend-ops`'s compute-and-compare model can't host it. Happy to add a separate death-test executable if maintainers prefer; let me know.

Credit to @janblumenkamp for the original bug analysis, complete reproducer, and historical research.