### PR TITLE
metal : graceful failure instead of GGML_ABORT

### DIFF
--- a/src/ggml-metal/ggml-metal-context.m
+++ b/src/ggml-metal/ggml-metal-context.m
@@ -71,6 +71,9 @@ struct ggml_metal {
     // abort ggml_metal_graph_compute if callback returns true
     ggml_abort_callback abort_callback;
     void *              abort_callback_data;
+
+    // set by ggml_metal_synchronize when a command buffer fails, checked by graph_compute
+    bool synchronize_failed;
 };
 
 ggml_metal_t ggml_metal_init(ggml_metal_device_t dev) {
@@ -232,7 +235,8 @@ void ggml_metal_synchronize(ggml_metal_t ctx) {
                 if (status == MTLCommandBufferStatusError) {
                     GGML_LOG_ERROR("error: %s\n", [[cmd_buf error].localizedDescription UTF8String]);
                 }
-                GGML_ABORT("fatal error");
+                ctx->synchronize_failed = true;
+                return;
             }
         }
     }
@@ -248,7 +252,13 @@ void ggml_metal_synchronize(ggml_metal_t ctx) {
                 if (status == MTLCommandBufferStatusError) {
                     GGML_LOG_ERROR("error: %s\n", [[cmd_buf error].localizedDescription UTF8String]);
                 }
-                GGML_ABORT("fatal error");
+                // release already-checked ext buffers before returning
+                for (size_t j = 0; j < i; ++j) {
+                    [ctx->cmd_bufs_ext[j] release];
+                }
+                [ctx->cmd_bufs_ext removeAllObjects];
+                ctx->synchronize_failed = true;
+                return;
             }
 
             [cmd_buf release];
@@ -357,6 +367,13 @@ void ggml_metal_get_tensor_async(ggml_metal_t ctx, const struct ggml_tensor * te
 }
 
 enum ggml_status ggml_metal_graph_compute(ggml_metal_t ctx, struct ggml_cgraph * gf) {
+    // if a previous synchronize detected a command buffer failure, propagate the error
+    if (ctx->synchronize_failed) {
+        GGML_LOG_ERROR("%s: previous Metal command buffer failure detected, returning GGML_STATUS_FAILED\n", __func__);
+        ctx->synchronize_failed = false;
+        return GGML_STATUS_FAILED;
+    }
+
     // number of nodes encoded by the main thread (empirically determined)
     const int n_main = 64;
 
@@ -515,6 +532,17 @@ enum ggml_status ggml_metal_graph_compute(ggml_metal_t ctx, struct ggml_cgraph *
             [ctx->capture_scope endScope];
             [[MTLCaptureManager sharedCaptureManager] stopCapture];
         }
+    }
+
+    // Synchronously verify this graph's command buffers so a GPU failure
+    // surfaces as GGML_STATUS_FAILED for THIS compute, rather than only at the
+    // next graph_compute (which never runs for the final graph, letting
+    // corrupted output pass as success). Callers read results right after each
+    // compute — forcing a synchronize anyway — so this adds negligible latency.
+    ggml_metal_synchronize(ctx);
+    if (ctx->synchronize_failed) {
+        ctx->synchronize_failed = false;
+        return GGML_STATUS_FAILED;
     }
 
     return GGML_STATUS_SUCCESS;

--- a/src/ggml-metal/ggml-metal-device.m
+++ b/src/ggml-metal/ggml-metal-device.m
@@ -605,7 +605,14 @@ void ggml_metal_rsets_free(ggml_metal_rsets_t rsets) {
     }
 
     // note: if you hit this assert, most likely you haven't deallocated all Metal resources before exiting
-    GGML_ASSERT([rsets->data count] == 0);
+    // rsets_free_patched: tolerate non-empty rsets during process exit
+    if ([rsets->data count] != 0) {
+        GGML_LOG_WARN("%s: %lu Metal resource sets still alive during teardown (process exiting)\n", __func__, (unsigned long)[rsets->data count]);
+        // Skip cleanup — resources will be reclaimed by the OS on exit.
+        // Continuing with free() here would use-after-free the leaked backends.
+        free(rsets);
+        return;
+    }
 
     atomic_store_explicit(&rsets->d_stop, true, memory_order_relaxed);
 


### PR DESCRIPTION
A failed Metal command buffer (device lost, OOM, GPU hang) currently calls GGML_ABORT inside ggml_metal_synchronize, which terminates the whole process. An application embedding ggml-metal has no way to catch this and recover.

Changes:
- ggml_metal_synchronize: replace the two GGML_ABORT with a synchronize_failed flag and an early return (releasing the already-checked external command buffers first).
- ggml_metal_graph_compute: check the flag at entry, and before returning success, synchronize and check its own command buffers, so a failure is reported as GGML_STATUS_FAILED for that compute rather than only the next one (which never runs for the final graph). The existing graph-compute callers already check `!= GGML_STATUS_SUCCESS`, so they get a clean error instead of the process aborting. Callers read results right after each compute, so the added synchronize costs little.
- ggml_metal_rsets_free: tolerate resource sets still alive at process teardown (warn and free the struct) instead of asserting, which otherwise use-after-frees the leaked backends on exit.

Testing: built ggml-metal with -DGGML_METAL=ON on macOS (Apple Silicon). The change converts an abort into a status code that the existing callers already check; I did not synthetically inject a command buffer error.

AI usage: I wrote the synchronize_failed flag, the GGML_ABORT removals, and the rsets_free teardown change. I used an AI assistant to add the end-of-compute synchronize check and to help word this description.