### PR TITLE
sycl: fix soft_max_f32 max reduction

### DIFF
--- a/src/ggml-sycl/softmax.cpp
+++ b/src/ggml-sycl/softmax.cpp
@@ -56,7 +56,7 @@ static void soft_max_f32(const float *         x,
                                : block_size_template;
     const int nthreads = block_size;
     const int nwarps = nthreads / WARP_SIZE;
-    size_t nreduce = nwarps / WARP_SIZE;
+    const size_t nreduce = nwarps / WARP_SIZE;
 
     const int tid = item_ct1.get_local_id(2);
 
@@ -105,17 +105,15 @@ static void soft_max_f32(const float *         x,
     max_val = warp_reduce_max<WARP_SIZE>(max_val);
 
     if (block_size > WARP_SIZE) {
-        if (warp_id == 0) {
-            buf_iw[lane_id] = -INFINITY;
-        }
-        item_ct1.barrier();
-
         if (lane_id == 0) {
             buf_iw[warp_id] = max_val;
         }
         item_ct1.barrier();
 
-        max_val = buf_iw[lane_id];
+        max_val = -INFINITY;
+        for (int i = lane_id; i < nwarps; i += WARP_SIZE) {
+            max_val = sycl::max(max_val, buf_iw[i]);
+        }
         max_val = warp_reduce_max<WARP_SIZE>(max_val);
     }
     float tmp = 0.0f; // partial sum
@@ -290,7 +288,8 @@ static void soft_max_f32_sycl(const float *x, const T *mask,
 
             cgh.parallel_for(
                 sycl::nd_range<3>(block_nums * block_dims, block_dims),
-                [=](sycl::nd_item<3> item_ct1) {
+                [=](sycl::nd_item<3> item_ct1)
+                    [[sycl::reqd_sub_group_size(WARP_SIZE)]] {
                     soft_max_f32<false, 0, 0>(
                         x, mask, sinks, dst, params,
                         dpct_local_acc_ct1


### PR DESCRIPTION
Fix the second-stage max reduction in the SYCL softmax kernel when a workgroup contains more subgroups than `WARP_SIZE`.

Previously, after each subgroup wrote its partial max to `buf_iw[warp_id]`, the cross-subgroup reduction only loaded:

```cpp
max_val = buf_iw[lane_id];
```

This only reduces the first `WARP_SIZE` partial maxima. For example, on Intel GPUs, `WARP_SIZE` can be 16 while the softmax workgroup size is 1024, producing nwarps = 64. In that case, partial maxima from `buf_iw[16..63]` were ignored.
If the true row max is in one of the ignored subgroups, softmax subtracts a too-small max value. For large attention logits this can overflow `exp(x - max)` to `inf`, eventually producing `NaN`.

llama.cpp PR: https://github.com/ggml-org/llama.cpp/pull/24451