### PR TITLE
CUDA/HIP: honor GGML_PREC_F32 in the flash-attention tile kernel

### DIFF
--- a/src/ggml-cuda/fattn-tile.cuh
+++ b/src/ggml-cuda/fattn-tile.cuh
@@ -370,6 +370,33 @@ static constexpr __device__ int ggml_cuda_fattn_tile_get_nbatch_K(const int DKQ,
     return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols) >> 23) & ((1 << 9) - 1);
 }
 
+// The GGML_PREC_F32 path stores Q/K/KQ in fp32 instead of fp16, which roughly doubles the
+// static shared-memory footprint of the tile kernel. On a fast-fp16 arch (where the fp16 config
+// was selected) this can exceed the 64 KiB LDS limit for a single block, so derive an LDS-safe
+// nbatch_K by shrinking it - keeping DV % nbatch_K == 0 and nbatch_K % cpy_ne == 0 - until the
+// Q_tmp + KV_tmp + KQ allocation fits one block. Occupancy is forced to 1 separately.
+static constexpr __device__ int ggml_cuda_fattn_tile_get_nbatch_K_f32(
+        const int DKQ, const int DV, const int ncols, const int nbatch_fa, const int nbatch_K_f16) {
+    constexpr int warp_size = 32;
+    const int DVp    = (DV + 2*warp_size - 1) & ~(2*warp_size - 1);
+    const int cpy_ne = ggml_cuda_get_max_cpy_bytes() / 4;
+    const int budget = (60*1024) / 4; // floats; stay safely below 64 KiB LDS for one block
+    // nbatch_K must be a multiple of 8 (flash_attn_tile_load_tile's J % 8 == 0) and divide DV.
+    // Return the largest such value <= the fp16 config's nbatch_K whose fp32 buffers fit, else 0
+    // (caller then keeps the fp16 path - fp32 storage is infeasible for this shape, e.g. DKQ 512).
+    const int step = 8;
+    for (int nk = (nbatch_K_f16 / step) * step; nk >= step; nk -= step) {
+        if ((DV % nk) != 0) {
+            continue;
+        }
+        const int floats = ncols*DKQ + (nbatch_fa*(nk + cpy_ne) + DVp - DV) + ncols*nbatch_fa;
+        if (floats <= budget) {
+            return nk;
+        }
+    }
+    return 0;
+}
+
 // TODO: deduplicate with mma-f16
 template<int warp_size, int nwarps, int I, int J, int J_padding, bool oob_check>
 static __device__ __forceinline__ void flash_attn_tile_load_tile(
@@ -499,39 +526,25 @@ static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
         (K_h2 + int64_t(k_VKQ_0)*stride_K2 + k_KQ_0/2, KV_tmp, stride_K2, k_VKQ_sup);
     __syncthreads();
 
-#ifdef FAST_FP16_AVAILABLE
-    static_assert((nbatch_K/2) % cpy_ne == 0, "bad nbatch_K");
+    constexpr bool use_fp16 = std::is_same<T_vec_dot, half2>::value;
+    constexpr int  kpack    = use_fp16 ? 2 : 1; // scalar values packed per T_vec_dot element
+    static_assert((nbatch_K/kpack) % cpy_ne == 0, "bad nbatch_K");
 #pragma unroll
-    for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K/2; k_KQ_1 += cpy_ne) {
-        __align__(16) half2 K_k[nbatch_fa/(np*warp_size)][cpy_ne];
-        __align__(16) half2 Q_k[cpw][cpy_ne];
-#else
-    static_assert(nbatch_K % cpy_ne == 0, "bad nbatch_K");
-#pragma unroll
-    for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K; k_KQ_1 += cpy_ne) {
-        __align__(16) float K_k[nbatch_fa/(np*warp_size)][cpy_ne];
-        __align__(16) float Q_k[cpw][cpy_ne];
-#endif // FAST_FP16_AVAILABLE
+    for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K/kpack; k_KQ_1 += cpy_ne) {
+        __align__(16) T_vec_dot K_k[nbatch_fa/(np*warp_size)][cpy_ne];
+        __align__(16) T_vec_dot Q_k[cpw][cpy_ne];
 
 #pragma unroll
         for (int i_KQ_0 = 0; i_KQ_0 < nbatch_fa; i_KQ_0 += np*warp_size) {
             const int i_KQ = i_KQ_0 + (threadIdx.y % np)*warp_size + threadIdx.x;
 
-#ifdef FAST_FP16_AVAILABLE
-            ggml_cuda_memcpy_1<cpy_nb>(&K_k[i_KQ_0/(np*warp_size)], &KV_tmp[i_KQ*(nbatch_K/2 + cpy_ne) + k_KQ_1]);
-#else
-            ggml_cuda_memcpy_1<cpy_nb>(&K_k[i_KQ_0/(np*warp_size)], &KV_tmp[i_KQ*(nbatch_K   + cpy_ne) + k_KQ_1]);
-#endif // FAST_FP16_AVAILABLE
+            ggml_cuda_memcpy_1<cpy_nb>(&K_k[i_KQ_0/(np*warp_size)], &KV_tmp[i_KQ*(nbatch_K/kpack + cpy_ne) + k_KQ_1]);
         }
 #pragma unroll
         for (int jc0 = 0; jc0 < cpw; ++jc0) {
             const int jc = jc0 + (threadIdx.y / np)*cpw;
 
-#ifdef FAST_FP16_AVAILABLE
-            ggml_cuda_memcpy_1<cpy_nb>(&Q_k[jc0], &Q_tmp[jc*(DKQ/2) + k_KQ_0/2 + k_KQ_1]);
-#else
-            ggml_cuda_memcpy_1<cpy_nb>(&Q_k[jc0], &Q_tmp[jc* DKQ    + k_KQ_0   + k_KQ_1]);
-#endif // FAST_FP16_AVAILABLE
+            ggml_cuda_memcpy_1<cpy_nb>(&Q_k[jc0], &Q_tmp[jc*(DKQ/kpack) + k_KQ_0/kpack + k_KQ_1]);
         }
 
 #pragma unroll
@@ -584,11 +597,8 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
 
     // KQ_cs == KQ chunk size, number of KQ values in j direction to store as one contiguous chunk in memory.
     // KQ is originally 2D but uses a Z-shaped 3D memory pattern like KQ[ncols/KQ_cs][DVp][KQ_cs].
-#ifdef FAST_FP16_AVAILABLE
-    constexpr int KQ_cs = cpw < 2*cpy_ne ? cpw : 2*cpy_ne;
-#else
-    constexpr int KQ_cs = cpw < 1*cpy_ne ? cpw : 1*cpy_ne;
-#endif // FAST_FP16_AVAILABLE
+    constexpr bool use_fp16 = std::is_same<T_vec_dot, half2>::value;
+    constexpr int  KQ_cs    = cpw < (use_fp16 ? 2 : 1)*cpy_ne ? cpw : (use_fp16 ? 2 : 1)*cpy_ne;
     static_assert(cpw % KQ_cs == 0, "bad KQ_cs");
     const int k_VKQ_sup = k_VKQ_max - k_VKQ_0; // k supremum, only smaller k values have valid KV data
 
@@ -623,9 +633,11 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
             const int i_KQ = i_KQ_0 + (threadIdx.y % np)*warp_size + threadIdx.x;
 
 #if defined(FAST_FP16_AVAILABLE) && !defined(V_DOT2_F32_F16_AVAILABLE)
-            // Without the v_dot2_f32_f16 instruction there is a higher risk of numerical overflow in the KQ calculation.
-            // Therefore, scale down Q values and apply the inverse scale the FP32 KQ values afterwards again.
-            KQ_acc[i_KQ_0/(np*warp_size)*cpw + jc0] *= 4.0f;
+            if constexpr (use_fp16) {
+                // Without the v_dot2_f32_f16 instruction there is a higher risk of numerical overflow in the KQ calculation.
+                // Therefore, scale down Q values and apply the inverse scale the FP32 KQ values afterwards again.
+                KQ_acc[i_KQ_0/(np*warp_size)*cpw + jc0] *= 4.0f;
+            }
 #endif // defined(FAST_FP16_AVAILABLE) && !defined(V_DOT2_F32_F16_AVAILABLE)
 
             if (use_logit_softcap) {
@@ -659,11 +671,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
     // Calculate KQ softmax, write to shared KQ buffer, re-scale VKQ accumulators:
 #pragma unroll
     for (int jc0 = 0; jc0 < cpw; jc0 += KQ_cs) {
-#ifdef FAST_FP16_AVAILABLE
-        __align__(16) half  tmp[nbatch_fa/(np*warp_size)][KQ_cs];
-#else
-        __align__(16) float tmp[nbatch_fa/(np*warp_size)][KQ_cs];
-#endif // FAST_FP16_AVAILABLE
+        __align__(16) T_KQ tmp[nbatch_fa/(np*warp_size)][KQ_cs];
 
 #pragma unroll
         for (int jc1 = 0; jc1 < KQ_cs; ++jc1) {
@@ -682,19 +690,19 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
             }
             KQ_sum[jc] = KQ_sum[jc]*KQ_max_scale + KQ_sum_add;
 
-#ifdef FAST_FP16_AVAILABLE
+            if constexpr (use_fp16) {
             const half2 KQ_max_scale_h2 = make_half2(KQ_max_scale, KQ_max_scale);
 #pragma unroll
             for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
                 VKQ[jc*((DVp/2)/warp_size) + i0/warp_size] *= KQ_max_scale_h2;
             }
-#else
+            } else {
 #pragma unroll
             for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
                 VKQ[jc*((DVp/2)/warp_size) + i0/warp_size].x *= KQ_max_scale;
                 VKQ[jc*((DVp/2)/warp_size) + i0/warp_size].y *= KQ_max_scale;
             }
-#endif // FAST_FP16_AVAILABLE
+            }
         }
 
 #pragma unroll
@@ -719,7 +727,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
             (V_h2 + int64_t(k_VKQ_0 + k0)*stride_V2, KV_tmp, stride_V2, k_VKQ_sup - k0);
         __syncthreads();
 
-#ifdef FAST_FP16_AVAILABLE
+        if constexpr (use_fp16) {
 #pragma unroll
         for (int k1 = 0; k1 < nbatch_V; k1 += np) {
             __align__(16) half2 V_k[(DVp/2)/warp_size];
@@ -751,7 +759,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
                 }
             }
         }
-#else
+        } else {
 #pragma unroll
         for (int k1 = 0; k1 < nbatch_V; k1 += np) {
             __align__(16) float2 V_k[(DVp/2)/warp_size];
@@ -779,14 +787,14 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
                 }
             }
         }
-#endif // FAST_FP16_AVAILABLE
+        }
 
         __syncthreads();
     }
 }
 
-template<int DKQ, int DV, int ncols1, int ncols2, bool use_logit_softcap> // D == head size
-__launch_bounds__(ggml_cuda_fattn_tile_get_nthreads(DKQ, DV, ncols1*ncols2), ggml_cuda_fattn_tile_get_occupancy(DKQ, DV, ncols1*ncols2))
+template<int DKQ, int DV, int ncols1, int ncols2, bool use_logit_softcap, bool prec_f32 = false> // D == head size
+__launch_bounds__(ggml_cuda_fattn_tile_get_nthreads(DKQ, DV, ncols1*ncols2), prec_f32 ? 1 : ggml_cuda_fattn_tile_get_occupancy(DKQ, DV, ncols1*ncols2))
 static __global__ void flash_attn_tile(
         const char * Q_ptr,
         const char * K_ptr,
@@ -846,7 +854,18 @@ static __global__ void flash_attn_tile(
     constexpr int warp_size = 32;
     constexpr int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, ncols1*ncols2) / warp_size;
     constexpr int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, ncols1*ncols2);
-    constexpr int nbatch_K  = ggml_cuda_fattn_tile_get_nbatch_K (DKQ, DV, ncols1*ncols2);
+#ifdef FAST_FP16_AVAILABLE
+    constexpr bool fast_fp16_avail = true;
+#else
+    constexpr bool fast_fp16_avail = false;
+#endif // FAST_FP16_AVAILABLE
+    // GGML_PREC_F32 (prec_f32) forces fp32 Q/K/KQ storage on a fast-fp16 arch to avoid the fp16
+    // KQ-accumulation error. That ~doubles LDS; if it cannot fit for this shape, fall back to fp16.
+    constexpr int  nbatch_K_f16cfg = ggml_cuda_fattn_tile_get_nbatch_K(DKQ, DV, ncols1*ncols2);
+    constexpr int  nbatch_K_f32fit = ggml_cuda_fattn_tile_get_nbatch_K_f32(DKQ, DV, ncols1*ncols2, nbatch_fa, nbatch_K_f16cfg);
+    constexpr bool force_f32 = fast_fp16_avail && prec_f32 && (nbatch_K_f32fit > 0);
+    constexpr bool use_fp16  = fast_fp16_avail && !force_f32;
+    constexpr int  nbatch_K  = force_f32 ? nbatch_K_f32fit : nbatch_K_f16cfg;
 
     // In this kernel Q, K, V are matrices while i, j, k are matrix indices.
 
@@ -883,17 +902,13 @@ static __global__ void flash_attn_tile(
     //     KV_tmp is padded to avoid memory conflicts for K (cpy_ne) and OOB accesses for V (DVp-DV).
     // KQ == SRAM buffer to hold KQ fragments between KQ and VKQ matrix multiplications.
     // VKQ == Accumulators in registers for the final VKQ result.
-#ifdef FAST_FP16_AVAILABLE
-    __shared__ half2 Q_tmp[ncols * DKQ/2];
-    __shared__ half2 KV_tmp[nbatch_fa * (nbatch_K/2 + cpy_ne) + DVp-DV];
-    __shared__ half  KQ[ncols * nbatch_fa];
-    __align__(16) half2 VKQ[cpw * ((DVp/2)/warp_size)] = {{0.0f, 0.0f}};
-#else
-    __shared__ float Q_tmp[ncols * DKQ];
-    __shared__ float KV_tmp[nbatch_fa * (nbatch_K + cpy_ne) + DVp-DV];
-    __shared__ float KQ[ncols * nbatch_fa];
-    __align__(16) float2 VKQ[cpw * ((DVp/2)/warp_size)] = {{0.0f, 0.0f}};
-#endif // FAST_FP16_AVAILABLE
+    using TQ   = std::conditional_t<use_fp16, half2, float>;  // Q_tmp / KV_tmp element
+    using TKQ  = std::conditional_t<use_fp16, half,  float>;  // KQ element
+    using TVKQ = std::conditional_t<use_fp16, half2, float2>; // VKQ accumulator element
+    __shared__ TQ  Q_tmp[ncols * (use_fp16 ? DKQ/2 : DKQ)];
+    __shared__ TQ  KV_tmp[nbatch_fa * ((use_fp16 ? nbatch_K/2 : nbatch_K) + cpy_ne) + DVp-DV];
+    __shared__ TKQ KQ[ncols * nbatch_fa];
+    __align__(16) TVKQ VKQ[cpw * ((DVp/2)/warp_size)] = {{0.0f, 0.0f}};
 
     float KQ_max[cpw];
 #pragma unroll
@@ -927,7 +942,7 @@ static __global__ void flash_attn_tile(
                     tmp_f[i1] *= scale;
                 }
 
-#ifdef FAST_FP16_AVAILABLE
+                if constexpr (use_fp16) {
                 __align__(16) half2 tmp_h2[cpy_ne_D/2];
 #pragma unroll
                 for (int i1 = 0; i1 < cpy_ne_D; i1 += 2) {
@@ -941,11 +956,11 @@ static __global__ void flash_attn_tile(
                 ggml_cuda_memcpy_1<sizeof(tmp_h2)>(
                     &Q_tmp[jc*(DKQ/2) + i0/2 + (threadIdx.y % np)*(warp_size*cpy_ne_D/2) + threadIdx.x*(cpy_ne_D/2)],
                     tmp_h2);
-#else
+                } else {
                 ggml_cuda_memcpy_1<sizeof(tmp_f)>(
                     &Q_tmp[jc* DKQ    + i0   + (threadIdx.y % np)*(warp_size*cpy_ne_D)   + threadIdx.x* cpy_ne_D],
                     tmp_f);
-#endif // FAST_FP16_AVAILABLE
+                }
             }
         }
     }
@@ -989,28 +1004,24 @@ static __global__ void flash_attn_tile(
         static_assert(cpw == 1, "bad cpw");
         static_assert(nbatch_fa*nbatch_K >= nwarps*DVp, "KV_tmp too small");
 
-#ifdef FAST_FP16_AVAILABLE
-        half2 * VKQ_combine    = (half2 *) KV_tmp;
-#else
-        float * VKQ_combine    = (float *) KV_tmp;
-#endif // FAST_FP16_AVAILABLE
+        TQ    * VKQ_combine    = KV_tmp;
         float * KQ_sum_combine = (float *) Q_tmp;
 
         if (threadIdx.y % np != 0) {
-#ifdef FAST_FP16_AVAILABLE
+            if constexpr (use_fp16) {
             constexpr int cpy_ne_D = cpy_ne < (DVp/2)/warp_size ? cpy_ne : (DVp/2)/warp_size;
 #pragma unroll
             for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
                 ggml_cuda_memcpy_1<cpy_ne_D*4>(&VKQ_combine[threadIdx.y*(DVp/2) + i0 + threadIdx.x*cpy_ne_D], &VKQ[i0/warp_size]);
             }
-#else
+            } else {
             constexpr int cpy_ne_D = cpy_ne < DVp/warp_size ? cpy_ne : DVp/warp_size;
 #pragma unroll
             for (int i0 = 0; i0 < DVp; i0 += warp_size*cpy_ne_D) {
                 ggml_cuda_memcpy_1<cpy_ne_D*4>(
                     &VKQ_combine[threadIdx.y*DVp + i0 + threadIdx.x*cpy_ne_D], ((const float *) VKQ) + i0/warp_size);
             }
-#endif // FAST_FP16_AVAILABLE
+            }
 
             if (threadIdx.x == 0) {
                 KQ_sum_combine[threadIdx.y] = KQ_sum[0];
@@ -1023,7 +1034,7 @@ static __global__ void flash_attn_tile(
 
 #pragma unroll
         for (int ip = 1; ip < np; ++ip) {
-#ifdef FAST_FP16_AVAILABLE
+            if constexpr (use_fp16) {
             constexpr int cpy_ne_D = cpy_ne < (DVp/2)/warp_size ? cpy_ne : (DVp/2)/warp_size;
 #pragma unroll
             for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
@@ -1034,7 +1045,7 @@ static __global__ void flash_attn_tile(
                     VKQ[i0/warp_size + i1] += tmp[i1];
                 }
             }
-#else
+            } else {
             constexpr int cpy_ne_D = cpy_ne < DVp/warp_size ? cpy_ne : DVp/warp_size;
 #pragma unroll
             for (int i0 = 0; i0 < DVp; i0 += warp_size*cpy_ne_D) {
@@ -1045,7 +1056,7 @@ static __global__ void flash_attn_tile(
                     ((float *)VKQ)[i0/warp_size + i1] += tmp[i1];
                 }
             }
-#endif // FAST_FP16_AVAILABLE
+            }
 
             KQ_sum[0] += KQ_sum_combine[threadIdx.y + ip];
         }
@@ -1065,19 +1076,19 @@ static __global__ void flash_attn_tile(
             const float val = expf(sink - KQ_max[jc0]);
             KQ_sum[jc0] = KQ_sum[jc0]*KQ_max_scale + val;
 
-#ifdef FAST_FP16_AVAILABLE
+            if constexpr (use_fp16) {
             const half2 KQ_max_scale_h2 = make_half2(KQ_max_scale, KQ_max_scale);
 #pragma unroll
             for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
                 VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size] *= KQ_max_scale_h2;
             }
-#else
+            } else {
 #pragma unroll
             for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
                 VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size].x *= KQ_max_scale;
                 VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size].y *= KQ_max_scale;
             }
-#endif // FAST_FP16_AVAILABLE
+            }
         }
     }
 
@@ -1097,7 +1108,7 @@ static __global__ void flash_attn_tile(
 
         const int j_dst_unrolled = ((sequence*int(ne01.z) + col_Q_0 + j)*ne02 + head0 + c)*gridDim.y + blockIdx.y;
 
-#ifdef FAST_FP16_AVAILABLE
+        if constexpr (use_fp16) {
         constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
 #pragma unroll
         for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
@@ -1112,7 +1123,7 @@ static __global__ void flash_attn_tile(
                 ggml_cuda_memcpy_1<sizeof(tmp)>(&dst[j_dst_unrolled*DV + 2*i0 + threadIdx.x*(2*cpy_ne_D)], tmp);
             }
         }
-#else
+        } else {
         constexpr int cpy_ne_D = cpy_ne < DVp/warp_size ? cpy_ne : DVp/warp_size;
 #pragma unroll
         for (int i0 = 0; i0 < DVp; i0 += warp_size*cpy_ne_D) {
@@ -1127,7 +1138,7 @@ static __global__ void flash_attn_tile(
                     &VKQ[jc0*((DVp/2)/warp_size) + i0/(2*warp_size)]);
             }
         }
-#endif // FAST_FP16_AVAILABLE
+        }
 
         if (gridDim.y != 1 && threadIdx.x == 0) {
             dst_meta[j_dst_unrolled] = make_float2(KQ_max[jc0], KQ_sum[jc0]);
@@ -1151,6 +1162,14 @@ template <int DKQ, int DV, int ncols2, bool use_logit_softcap>
 static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * Q = dst->src[0];
 
+#ifdef GGML_USE_HIP
+    // On AMD the tile kernel is the non-GQA fallback (no rocWMMA fattn). Honor GGML_PREC_F32 there:
+    // the default fp16 Q/K storage loses precision on large activations and corrupts the result.
+    const bool prec_f32 = ggml_flash_attn_ext_get_prec(dst) == GGML_PREC_F32;
+#else
+    const bool prec_f32 = false;
+#endif // GGML_USE_HIP
+
     const int id        = ggml_cuda_get_device();
     const int cc        = ggml_cuda_info().devices[id].cc;
     const int warp_size = 32;
@@ -1163,7 +1182,9 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
             constexpr int cols_per_block = 64;
             const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
             const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap>;
+            fattn_kernel_t fattn_kernel = prec_f32
+                ? flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, true>
+                : flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, false>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa, true, true, false, warp_size);
             return;
@@ -1179,7 +1200,9 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
             constexpr int cols_per_block = 32;
             const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
             const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap>;
+            fattn_kernel_t fattn_kernel = prec_f32
+                ? flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, true>
+                : flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, false>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa, true, true, false, warp_size);
             return;
@@ -1191,7 +1214,9 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
             constexpr int cols_per_block = 16;
             const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
             const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap>;
+            fattn_kernel_t fattn_kernel = prec_f32
+                ? flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, true>
+                : flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, false>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa, true, true, false, warp_size);
             return;
@@ -1203,7 +1228,9 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
             constexpr int cols_per_block = 8;
             const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
             const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap>;
+            fattn_kernel_t fattn_kernel = prec_f32
+                ? flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, true>
+                : flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, false>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa, true, true, false, warp_size);
             return;
@@ -1215,7 +1242,9 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
             constexpr int cols_per_block = 4;
             const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
             const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap>;
+            fattn_kernel_t fattn_kernel = prec_f32
+                ? flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, true>
+                : flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, false>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa, true, true, false, warp_size);
             return;


### PR DESCRIPTION
## Summary

The flash-attention **tile** kernel (`fattn-tile.cuh`) selects fp16 vs fp32 storage for Q/K and the KQ buffer from the compile-time arch capability (`FAST_FP16_AVAILABLE`) only, and ignores the op's requested precision (`ggml_flash_attn_ext_get_prec(dst) == GGML_PREC_F32`). On a fast-fp16 arch it therefore always down-casts Q and K to fp16 before the dot product, even when the graph asked for fp32.

The fp16 down-cast is usually harmless, but it is **value/scale dependent**: with large activations and a long key length the per-element rounding of Q·K compounds across layers and sampling steps into a visibly corrupted result (a doubled / "ghosted" subject in an image-diffusion model). This is the kernel AMD GPUs fall back to for **non-GQA** attention when built without rocWMMA flash-attention, so it is reachable in practice.

This PR makes the tile kernel **honor `GGML_PREC_F32`**: when fp32 is requested on a fast-fp16 arch, Q/K/KQ are stored in fp32. Where the wider fp32 buffers cannot fit shared memory for a given head size, the kernel transparently keeps the existing fp16 path (no regression for those shapes).

## Reproduction

Chroma (Flux-schnell arch, non-GQA, head_dim 128) via stable-diffusion.cpp on an AMD RDNA4 GPU (gfx1201), HIP, ggml built **without** rocWMMA flash-attention:

- 256² / 768²: clean.
- 1024² (≈4608 keys, fp32 model): **ghosted/doubled subject.**

It is invisible to `test-backend-ops` (synthetic near-uniform inputs do not excite the fp16 rounding) and to small/low-step generations. A **CPU-backend** run of the identical graph is clean; a per-node CPU-vs-HIP comparison (`ggml_backend_compare_graph_backend`) puts the first significant divergence on the `FLASH_ATTN_EXT` node (NMSE ≈ 2.2e-2 there vs ~1e-5 on every feeding op).

## Change

- Add a `bool prec_f32` template parameter to `flash_attn_tile`; `launch_fattn_tile_switch_ncols1` reads `ggml_flash_attn_ext_get_prec(dst)` (under `#ifdef GGML_USE_HIP`) and instantiates accordingly.
- `use_fp16 = fast_fp16_avail && !prec_f32` drives conditional buffer **types** (`std::conditional_t`) and **sizes**. The per-branch `#ifdef FAST_FP16_AVAILABLE` blocks in `flash_attn_tile`, `flash_attn_tile_iter` and `flash_attn_tile_iter_KQ` become `if constexpr (use_fp16)` (plus a `kpack = use_fp16 ? 2 : 1` factor on the already-templated `T_vec_dot` buffer type), so there is no logic duplication.
- fp32 storage roughly doubles shared memory. A constexpr helper shrinks `nbatch_K` (kept a multiple of 8 and a divisor of `DV`) until the `Q_tmp + KV_tmp + KQ` allocation fits one block, and forces occupancy to 1. If no fitting `nbatch_K` exists (e.g. head size 512/576, where `Q_tmp` alone exceeds the budget) it returns 0 and the kernel **falls back to the fp16 path** for that shape — those shapes are byte-for-byte unchanged.

Scope: gated to HIP. On CUDA the tile kernel is the pre-Pascal fallback (already using the fp32 path) and modern CUDA uses the mma kernel for these shapes, so the CUDA tile path is unchanged; the gating could be extended to CUDA if desired.

## Validation

AMD Radeon AI PRO R9700 (gfx1201), ROCm 7.2.4, ggml `master`, **without** rocWMMA flash-attention, Chroma1-HD fp16, FA + mask, 1024², 20 steps, seed 42:

- **Before:** ghosted/doubled subject.
- **After:** clean, correct image (matches the CPU / CUDA / Vulkan reference and the rocWMMA-fattn output).

`test-backend-ops` unchanged; 256²/768² (already clean) stay clean; 512/576 head sizes fall back to fp16.

## Performance / when it matters

The fp32 tile path is a **shader fp32** path (no matrix cores), so it is substantially slower than the fp16 tile path (~6× on the validated 1024² case) — it is a **correctness** fix. On RDNA3/RDNA4 the fast *and* correct path is `-DGGML_HIP_ROCWMMA_FATTN=ON` (the matrix-core fp32 WMMA kernel); this fix matters most for AMD **without** rocWMMA flash-attention (e.g. RDNA2, or rocWMMA < 2.0), where the tile kernel would otherwise return silently wrong results for an fp32-precision request.

## Notes

- The fp32 `nbatch_K`/occupancy heuristic (60 KiB budget, occupancy 1, `nbatch_K` on multiples of 8) is deliberately conservative to guarantee it fits; happy to replace it with tuned per-`(DKQ, DV, ncols)` fp32 config entries (mirroring `..._nvidia_fp32`) if you prefer that style.
- Only `fattn-tile.cuh` changes; the no-mask / non-fp32 / fp16 paths are unchanged.

Surfaced via [leejet/stable-diffusion.cpp#1625](https://github.com/leejet/stable-diffusion.cpp/pull/1625) (masked flash-attention shape fix); that PR's HIP note describes this corruption as a separate ggml-side issue.

_Opening as a draft pending maintainer preference on the fp32 config style (conservative heuristic vs. explicit tuned table)._
