### PR TITLE
opencl: fix Q4_0 SOA rows and Adreno paths

### DIFF
--- a/src/ggml-opencl/ggml-opencl.cpp
+++ b/src/ggml-opencl/ggml-opencl.cpp
@@ -593,6 +593,7 @@ struct ggml_backend_opencl_context {
     ggml_cl_buffer prealloc_src1;
 
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+    std::mutex transpose_2d_mutex;
     ggml_cl_buffer prealloc_adreno_xmem_const;
     bool adreno_xmem_gemm_enabled = false;
 #endif
@@ -989,6 +990,7 @@ struct ggml_backend_opencl_context {
     cl_program program_transpose;
 
     cl_kernel kernel_transpose_32;
+    cl_kernel kernel_transpose_32_32;
     cl_kernel kernel_transpose_32_16;
     cl_kernel kernel_transpose_16;
     cl_kernel kernel_transpose_8_buf;
@@ -998,6 +1000,7 @@ struct ggml_backend_opencl_context {
 
     // Gemm and Gemv related programs, kernels, etc
     cl_kernel kernel_gemm_noshuffle_q4_0_f32;
+    cl_kernel kernel_gemm_noshuffle_q4_0_f32_f32act;
     cl_kernel kernel_gemv_noshuffle_q4_0_f32;
     cl_kernel kernel_gemv_noshuffle_q4_0_f32_4096_1_11008;
     cl_kernel kernel_gemv_noshuffle_q4_0_f32_4096_1_4096;
@@ -3210,6 +3213,7 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx) {
             build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
 
         CL_CHECK((backend_ctx->kernel_transpose_32_16 = clCreateKernel(backend_ctx->program_transpose, "kernel_transpose_32_16", &err), err));
+        CL_CHECK((backend_ctx->kernel_transpose_32_32 = clCreateKernel(backend_ctx->program_transpose, "kernel_transpose_32_32", &err), err));
         CL_CHECK((backend_ctx->kernel_transpose_32    = clCreateKernel(backend_ctx->program_transpose, "kernel_transpose_32", &err), err));
         CL_CHECK((backend_ctx->kernel_transpose_16    = clCreateKernel(backend_ctx->program_transpose, "kernel_transpose_16", &err), err));
         CL_CHECK((backend_ctx->kernel_transpose_8_buf  = clCreateKernel(backend_ctx->program_transpose, "kernel_transpose_8_buf", &err), err));
@@ -3374,6 +3378,11 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx) {
 #endif
         cl_program prog = build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src_CL_gemm.c_str(), compile_opts);
         CL_CHECK((backend_ctx->kernel_gemm_noshuffle_q4_0_f32 = clCreateKernel(prog, "kernel_gemm_noshuffle_q4_0_f32", &err), err));
+        CL_CHECK(clReleaseProgram(prog));
+
+        std::string compile_opts_f32act = compile_opts + " -DUSE_F32_ACT=1";
+        prog = build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src_CL_gemm.c_str(), compile_opts_f32act);
+        CL_CHECK((backend_ctx->kernel_gemm_noshuffle_q4_0_f32_f32act = clCreateKernel(prog, "kernel_gemm_noshuffle_q4_0_f32", &err), err));
         CL_CHECK(clReleaseProgram(prog));
         GGML_LOG_CONT(".");
     }
@@ -5623,7 +5632,7 @@ static void transpose_2d(
     cl_int stride, cl_int rows,
     bool blocking = true
 ) {
-    static ggml_cl_buffer buf;
+    ggml_cl_buffer buf;
 
     cl_event evt;
     cl_int err;
@@ -5638,6 +5647,8 @@ static void transpose_2d(
     CL_CHECK((trans = clCreateSubBuffer(
         buf.buffer, CL_MEM_READ_WRITE,
         CL_BUFFER_CREATE_TYPE_REGION, &region, &err), err));
+
+    std::lock_guard<std::mutex> lock(backend_ctx->transpose_2d_mutex);
 
     CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &src));
     CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &trans));
@@ -6434,6 +6445,15 @@ inline bool use_adreno_kernels(const ggml_backend_opencl_context *backend_ctx, c
     return threashold_ok;
 }
 
+static inline bool use_adreno_q4_0_f32_activation_gemm(const ggml_tensor * tensor) {
+    if (tensor == nullptr || tensor->type != GGML_TYPE_Q4_0 || tensor->name[0] == '\0') {
+        return false;
+    }
+
+    return strstr(tensor->name, "attention.qkv.weight") != nullptr ||
+           strstr(tensor->name, "attention.out.weight") != nullptr;
+}
+
 inline bool use_adreno_moe_kernels(const ggml_backend_opencl_context *backend_ctx, const ggml_tensor *tensor) {
     GGML_UNUSED(backend_ctx);
     int ne01 = tensor->ne[1];
@@ -6454,6 +6474,20 @@ static inline bool use_flat_gemv_for_large_m_q4_K(const ggml_tensor *tensor) {
     // threshold is well above typical hidden/FFN dims, but below typical vocab sizes.
     // note that this forces large M weights to use LM GEMM.
     return tensor->ne[1] >= 32768 && tensor->ne[2] == 1 && tensor->ne[3] == 1;
+}
+
+static inline bool opencl_uses_soa_quant_extra(enum ggml_type type) {
+#ifdef GGML_OPENCL_SOA_Q
+    return type == GGML_TYPE_Q4_0  || type == GGML_TYPE_Q4_1 ||
+           type == GGML_TYPE_Q5_0  || type == GGML_TYPE_Q5_1 ||
+           type == GGML_TYPE_Q8_0  || type == GGML_TYPE_IQ4_NL ||
+           type == GGML_TYPE_MXFP4 ||
+           type == GGML_TYPE_Q4_K  || type == GGML_TYPE_Q5_K ||
+           type == GGML_TYPE_Q6_K;
+#else
+    GGML_UNUSED(type);
+    return false;
+#endif
 }
 
 static inline bool use_flat_gemv_for_large_m_q6_K(const ggml_tensor *tensor) {
@@ -6495,12 +6529,7 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                 case GGML_TYPE_F16:
                     return true;
                 case GGML_TYPE_Q4_0:
-#ifdef GGML_OPENCL_SOA_Q
-                    // We do not support flattened Q4_0 (and possibly other Q's)
-                    return false;
-#else // GGML_OPENCL_SOA_Q
                     return true;
-#endif // GGML_OPENCL_SOA_Q
                 default:
                     return false;
             }
@@ -7491,7 +7520,8 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
         // Adreno moe q4_0 kernel needs special transpose and unshuffling
         if (use_adreno_moe_kernels(backend_ctx, tensor)) {
-            cl_kernel kernel = backend_ctx->kernel_convert_block_q4_0_trans4_ns;
+            cl_kernel kernel;
+            CL_CHECK((kernel = clCreateKernel(backend_ctx->program_cvt, "kernel_convert_block_q4_0_trans4_ns", &err), err));
 
             int ne00 = tensor->ne[0];
             int ne01 = tensor->ne[1];
@@ -7508,6 +7538,7 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
             cl_event evt;
             CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
             CL_CHECK(clWaitForEvents(1, &evt));
+            CL_CHECK(clReleaseKernel(kernel));
             CL_CHECK(clReleaseMemObject(data_device));
 
             // Create image for Q
@@ -7528,15 +7559,17 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
 
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
-        cl_kernel kernel = backend_ctx->kernel_convert_block_q4_0;
+        const char * kernel_name = "kernel_convert_block_q4_0";
 
         // The optimized kernels need weights in natural order, so unshuffle.
         if (use_adreno_kernels(backend_ctx, tensor)) {
-            kernel = backend_ctx->kernel_convert_block_q4_0_noshuffle;
+            kernel_name = "kernel_convert_block_q4_0_noshuffle";
         }
 #else
-        cl_kernel kernel = backend_ctx->kernel_convert_block_q4_0;
+        const char * kernel_name = "kernel_convert_block_q4_0";
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
+        cl_kernel kernel;
+        CL_CHECK((kernel = clCreateKernel(backend_ctx->program_cvt, kernel_name, &err), err));
         CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &data_device));
         CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->q));
         CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->d));
@@ -7547,6 +7580,7 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         cl_event evt;
         CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
         CL_CHECK(clWaitForEvents(1, &evt));
+        CL_CHECK(clReleaseKernel(kernel));
         CL_CHECK(clReleaseMemObject(data_device));
 
         tensor->extra = extra;
@@ -7557,7 +7591,7 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         // Only do transpose for large, non batched matrix
         // TODO: use preallocated images instead of sub-buffer then image
         if (use_adreno_kernels(backend_ctx, tensor)) {
-        int M = tensor->ne[1];
+            int M = tensor->ne[1];
             int K = tensor->ne[0];
 
             GGML_ASSERT(K % 32 == 0);
@@ -10449,11 +10483,10 @@ static void ggml_cl_get_rows(ggml_backend_t backend, const ggml_tensor * src0, c
 
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
 
-    ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
     ggml_tensor_extra_cl * extra1 = (ggml_tensor_extra_cl *)src1->extra;
     ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
 
-    cl_ulong offset0 = extra0->offset + src0->view_offs;
+    cl_ulong offset0 = 0;
     cl_ulong offset1 = extra1->offset + src1->view_offs;
     cl_ulong offsetd = extrad->offset + dst->view_offs;
 
@@ -10473,7 +10506,33 @@ static void ggml_cl_get_rows(ggml_backend_t backend, const ggml_tensor * src0, c
             GGML_ASSERT(false && "not implemented");
     }
 
-    CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0->data_device));
+    cl_mem src0_data_device = nullptr;
+    cl_mem src0_q4_0_d_device = nullptr;
+    int q4_0_layout = 0;
+    int q4_0_ne01 = src0->ne[1];
+
+#ifdef GGML_OPENCL_SOA_Q
+    if (src0->type == GGML_TYPE_Q4_0) {
+        ggml_tensor_extra_cl_q4_0 * extra0_q4_0 = (ggml_tensor_extra_cl_q4_0 *)src0->extra;
+        src0_data_device = extra0_q4_0->q;
+        src0_q4_0_d_device = extra0_q4_0->d;
+        q4_0_layout = 1;
+#ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+        if (use_adreno_moe_kernels(backend_ctx, src0)) {
+            q4_0_layout = 3;
+        } else if (use_adreno_kernels(backend_ctx, src0)) {
+            q4_0_layout = 2;
+        }
+#endif
+    }
+#endif
+    if (src0_data_device == nullptr) {
+        ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
+        offset0 = extra0->offset + src0->view_offs;
+        src0_data_device = extra0->data_device;
+        src0_q4_0_d_device = src0_data_device;
+    }
+    CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &src0_data_device));
     CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_ulong), &offset0));
     CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra1->data_device));
     CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_ulong), &offset1));
@@ -10490,6 +10549,11 @@ static void ggml_cl_get_rows(ggml_backend_t backend, const ggml_tensor * src0, c
     CL_CHECK(clSetKernelArg(kernel, 14, sizeof(cl_ulong), &nb1));
     CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_ulong), &nb2));
     CL_CHECK(clSetKernelArg(kernel, 16, sizeof(cl_ulong), &nb3));
+    if (src0->type == GGML_TYPE_Q4_0) {
+        CL_CHECK(clSetKernelArg(kernel, 17, sizeof(cl_mem), &src0_q4_0_d_device));
+        CL_CHECK(clSetKernelArg(kernel, 18, sizeof(int),    &q4_0_layout));
+        CL_CHECK(clSetKernelArg(kernel, 19, sizeof(int),    &q4_0_ne01));
+    }
 
     int max_workgroup_size = backend_ctx->get_kernel_workgroup_size(kernel);
     int nth = 1;
@@ -12051,7 +12115,7 @@ static void ggml_opencl_op_rms_norm_fused(ggml_backend_t backend, ggml_tensor * 
     ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
 
     cl_ulong offset0 = extra0->offset + src0->view_offs;
-    cl_ulong offset1 = extra1->offset + src0->view_offs;
+    cl_ulong offset1 = extra1->offset + src1->view_offs;
     cl_ulong offsetd = extrad->offset + dst->view_offs;
 
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
@@ -15270,15 +15334,16 @@ static void ggml_cl_mul_mat_q4_0_f32_adreno(ggml_backend_t backend, const ggml_t
         if (extra_elements > 0){
             padding = 8 - extra_elements;
         }
+        const bool use_f32_act = use_adreno_q4_0_f32_activation_gemm(src0);
 
         // subbuffer for transposed activations
         region.origin = 0;
-        region.size = K * (N + padding) * sizeof(float)/2;
+        region.size = K * (N + padding) * (use_f32_act ? sizeof(float) : sizeof(float)/2);
         backend_ctx->prealloc_act_trans.allocate(context, region.size);
         CL_CHECK((b_sub_buf_trans = clCreateSubBuffer(backend_ctx->prealloc_act_trans.buffer, 0, CL_BUFFER_CREATE_TYPE_REGION, &region, &err), err));
 
         // image for transposed activations
-        img_fmt = {CL_RGBA, CL_HALF_FLOAT};
+        img_fmt = {CL_RGBA, static_cast<cl_channel_type>(use_f32_act ? CL_FLOAT : CL_HALF_FLOAT)};
         memset(&img_desc, 0, sizeof(img_desc));
         img_desc.image_type = CL_MEM_OBJECT_IMAGE1D_BUFFER;
         img_desc.image_width = K * (N + padding) / 4;
@@ -15298,15 +15363,22 @@ static void ggml_cl_mul_mat_q4_0_f32_adreno(ggml_backend_t backend, const ggml_t
         int width_B = K/4;
         int padded_height_B = (N + padding)/4;
 
-        kernel = backend_ctx->kernel_transpose_32_16;
+        if (use_f32_act) {
+            kernel = padding == 0 ? backend_ctx->kernel_transpose_32 : backend_ctx->kernel_transpose_32_32;
+        } else {
+            kernel = backend_ctx->kernel_transpose_32_16;
+        }
         CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &b_img));
         CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &b_img_trans));
-        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(int),    &height_B));
+        const int transpose_rows = (use_f32_act && padding == 0) ? height_B : N;
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(int),    &transpose_rows));
         CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int),    &width_B));
-        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int),    &padded_height_B));
+        if (!use_f32_act || padding != 0) {
+            CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int), &padded_height_B));
+        }
 
         size_t local_work_size_t[2] = { 1, 16 };
-        size_t global_work_size_t[2] = { (size_t)width_B, (size_t)padded_height_B };
+        size_t global_work_size_t[2] = { (size_t)width_B, (size_t)((use_f32_act && padding == 0) ? height_B : padded_height_B) };
         if (ne0 == 4096 && ne1 == 128 && ne10 == 4096) {
             local_work_size_t[0]=4;
             local_work_size_t[1]=8;
@@ -15323,7 +15395,7 @@ static void ggml_cl_mul_mat_q4_0_f32_adreno(ggml_backend_t backend, const ggml_t
         backend_ctx->enqueue_ndrange_kernel(kernel, 2, global_work_size_t, local_work_size_t, dst);
 
         // gemm
-        kernel = backend_ctx->kernel_gemm_noshuffle_q4_0_f32;
+        kernel = use_f32_act ? backend_ctx->kernel_gemm_noshuffle_q4_0_f32_f32act : backend_ctx->kernel_gemm_noshuffle_q4_0_f32;
         int padded_N = N + padding;
 
         CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra0_q4_0->q));
@@ -17234,11 +17306,15 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
         return;
     }
 
-    ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
+    ggml_tensor_extra_cl * extra0 = nullptr;
     ggml_tensor_extra_cl * extra1 = (ggml_tensor_extra_cl *)src1->extra;
     ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
 
-    cl_ulong offset0 = extra0->offset + src0->view_offs;
+    cl_ulong offset0 = 0;
+    if (!opencl_uses_soa_quant_extra(src0->type)) {
+        extra0 = (ggml_tensor_extra_cl *)src0->extra;
+        offset0 = extra0->offset + src0->view_offs;
+    }
     cl_ulong offset1 = extra1->offset + src1->view_offs;
     cl_ulong offsetd = extrad->offset + dst->view_offs;
 
@@ -19403,12 +19479,16 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
 
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
 
-    ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
+    ggml_tensor_extra_cl * extra0 = nullptr;
     ggml_tensor_extra_cl * extra1 = (ggml_tensor_extra_cl *)src1->extra;
     ggml_tensor_extra_cl * extra2 = (ggml_tensor_extra_cl *)src2->extra;
     ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
 
-    cl_ulong offset0 = extra0->offset + src0->view_offs;
+    cl_ulong offset0 = 0;
+    if (!opencl_uses_soa_quant_extra(src0->type)) {
+        extra0 = (ggml_tensor_extra_cl *)src0->extra;
+        offset0 = extra0->offset + src0->view_offs;
+    }
     cl_ulong offset1 = extra1->offset + src1->view_offs;
     cl_ulong offset2 = extra2->offset + src2->view_offs;
     cl_ulong offsetd = extrad->offset + dst->view_offs;

--- a/src/ggml-opencl/kernels/gemm_noshuffle_q4_0_f32.cl
+++ b/src/ggml-opencl/kernels/gemm_noshuffle_q4_0_f32.cl
@@ -35,23 +35,39 @@ kernel void kernel_gemm_noshuffle_q4_0_f32(
     int gx = get_global_id(1);
     int gx_2 = gx << 2;
 
-    half8 c0 = 0, c1 = 0, c2 = 0, c3 = 0; // 8x4 output elements
-    half8 B; // registers for activations
-    half4 dequantized_weights; // registers for dequantized weights
+#ifdef USE_F32_ACT
+#define ACC_TYPE float8
+#define ACT_TYPE float8
+#define WEIGHT_TYPE float4
+#define SCALE_TYPE float4
+#define LOAD_ACT4(img, idx) read_imagef((img), (idx))
+#define LOAD_SCALE4(ptr) convert_float4(vload4(0, (ptr)))
+#else
+#define ACC_TYPE half8
+#define ACT_TYPE half8
+#define WEIGHT_TYPE half4
+#define SCALE_TYPE half4
+#define LOAD_ACT4(img, idx) read_imageh((img), (idx))
+#define LOAD_SCALE4(ptr) vload4(0, (ptr))
+#endif
+
+    ACC_TYPE c0 = 0, c1 = 0, c2 = 0, c3 = 0; // 8x4 output elements
+    ACT_TYPE B; // registers for activations
+    WEIGHT_TYPE dequantized_weights; // registers for dequantized weights
     __global const ushort* weight_ptr = src0_q + gx_2; // pointer for weights
     __global const half* scale_ptr = src0_d + gx_2; // pointer for scales
 
     for(int i=0; i<k; i+=4){ //loop through K dimension
 
-        B.s0123 = read_imageh(src1, gy*2 + (i)*(n_4));
-        B.s4567 = read_imageh(src1, gy*2 + (i)*(n_4)+1);
+        B.s0123 = LOAD_ACT4(src1, gy*2 + (i)*(n_4));
+        B.s4567 = LOAD_ACT4(src1, gy*2 + (i)*(n_4)+1);
 
         // keep (i/4) and (i/32) in parenthesis, rounds down
         // load 4 consecutive groups of 4 weights
         ushort4 bits4 = vload4(0, weight_ptr + (i/4)*(m)); // (i/4) because weights grouped in 4s
 
         // load 4 consecutive scales
-        half4 scale = vload4(0, scale_ptr + (i/32)*(m));// (i/32) because 1 scale per 32 elements
+        SCALE_TYPE scale = LOAD_SCALE4(scale_ptr + (i/32)*(m));// (i/32) because 1 scale per 32 elements
 
         // j=0
         dequantized_weights.s0 = ((bits4.s0 & (0x000F)) - 8) * scale.s0; // dequantize a row of the 16 weights
@@ -64,8 +80,8 @@ kernel void kernel_gemm_noshuffle_q4_0_f32(
         c3 += B * dequantized_weights.s3;
 
         // j=1
-        B.s0123 = read_imageh(src1, gy*2 + (i+1)*(n_4));
-        B.s4567 = read_imageh(src1, gy*2 + (i+1)*(n_4)+1);
+        B.s0123 = LOAD_ACT4(src1, gy*2 + (i+1)*(n_4));
+        B.s4567 = LOAD_ACT4(src1, gy*2 + (i+1)*(n_4)+1);
         dequantized_weights.s0 = (((bits4.s0 & (0x00F0)) >> 4) - 8) * scale.s0; // dequantize a row of the 16 weights
         dequantized_weights.s1 = (((bits4.s1 & (0x00F0)) >> 4) - 8) * scale.s1;
         dequantized_weights.s2 = (((bits4.s2 & (0x00F0)) >> 4) - 8) * scale.s2;
@@ -76,8 +92,8 @@ kernel void kernel_gemm_noshuffle_q4_0_f32(
         c3 += B * dequantized_weights.s3;
 
         // j=2
-        B.s0123 = read_imageh(src1, gy*2 + (i+2)*(n_4));
-        B.s4567 = read_imageh(src1, gy*2 + (i+2)*(n_4)+1);
+        B.s0123 = LOAD_ACT4(src1, gy*2 + (i+2)*(n_4));
+        B.s4567 = LOAD_ACT4(src1, gy*2 + (i+2)*(n_4)+1);
         dequantized_weights.s0 = (((bits4.s0 & (0x0F00)) >> 8) - 8) * scale.s0; // dequantize a row of the 16 weights
         dequantized_weights.s1 = (((bits4.s1 & (0x0F00)) >> 8) - 8) * scale.s1;
         dequantized_weights.s2 = (((bits4.s2 & (0x0F00)) >> 8) - 8) * scale.s2;
@@ -88,8 +104,8 @@ kernel void kernel_gemm_noshuffle_q4_0_f32(
         c3 += B * dequantized_weights.s3;
 
         // j=3
-        B.s0123 = read_imageh(src1, gy*2 + (i+3)*(n_4));
-        B.s4567 = read_imageh(src1, gy*2 + (i+3)*(n_4)+1);
+        B.s0123 = LOAD_ACT4(src1, gy*2 + (i+3)*(n_4));
+        B.s4567 = LOAD_ACT4(src1, gy*2 + (i+3)*(n_4)+1);
         dequantized_weights.s0 = (((bits4.s0 & (0xF000)) >> 12) - 8) * scale.s0; // dequantize a row of the 16 weights
         dequantized_weights.s1 = (((bits4.s1 & (0xF000)) >> 12) - 8) * scale.s1;
         dequantized_weights.s2 = (((bits4.s2 & (0xF000)) >> 12) - 8) * scale.s2;
@@ -136,4 +152,11 @@ kernel void kernel_gemm_noshuffle_q4_0_f32(
     if(idx+3 < m*n_no_padding){
         vstore4((float4)(c0.s7, c1.s7, c2.s7, c3.s7), 0, dst + idx);
     }
+
+#undef ACC_TYPE
+#undef ACT_TYPE
+#undef WEIGHT_TYPE
+#undef SCALE_TYPE
+#undef LOAD_ACT4
+#undef LOAD_SCALE4
 }

--- a/src/ggml-opencl/kernels/get_rows.cl
+++ b/src/ggml-opencl/kernels/get_rows.cl
@@ -18,6 +18,13 @@ struct block_q4_0
     uint8_t qs[QK4_0 / 2];
 };
 
+enum {
+    Q4_0_LAYOUT_AOS = 0,
+    Q4_0_LAYOUT_SOA = 1,
+    Q4_0_LAYOUT_ADRENO_TRANSPOSED = 2,
+    Q4_0_LAYOUT_ADRENO_MOE_TRANS4 = 3,
+};
+
 
 //------------------------------------------------------------------------------
 // dequantize_q4_0_f32, dequantize_q4_0_f16
@@ -164,13 +171,16 @@ kernel void kernel_get_rows_q4_0(
         ulong nb12,
         ulong nb1,
         ulong nb2,
-        ulong nb3
+        ulong nb3,
+        global void * src0_d,
+        int q4_0_layout,
+        int ne01
 ) {
     src0 = (global void*)((global char*)src0 + offset0);
     src1 = (global int*)((global char*)src1 + offset1);
     dst = (global float*)((global char*)dst + offsetd);
 
-    const int NL = 2;
+    const int block_size = sizeof(struct block_q4_0);
 
     int i10 = get_group_id(0);
     int i11 = get_group_id(1);
@@ -180,14 +190,67 @@ kernel void kernel_get_rows_q4_0(
 
     int i02 = i11;
     int i03 = i12;
+    const int nb = ne00 / QK4_0;
+    const ulong row_byte_offset = (ulong)r*nb01 + (ulong)i02*nb02 + (ulong)i03*nb03;
+    const ulong row_block_offset = row_byte_offset / block_size;
 
     for (int ind = get_local_id(0); ind < ne00/16; ind += get_local_size(0)) {
-        float16 temp;
-        if (ind >= ne00) {
-            return;
+        const int ib = ind / 2;
+        const int ih = ind & 1;
+        half d;
+        global float * dst_row = (global float *) ((global char *) dst + (ulong)i12*nb3 + (ulong)i11*nb2 + (ulong)i10*nb1);
+        const int dst_base = ind * 16;
+
+        if (q4_0_layout == Q4_0_LAYOUT_ADRENO_TRANSPOSED) {
+            global uchar * q = (global uchar *) src0;
+            global half * scales = (global half *) src0_d;
+            d = scales[ib * ne01 + r];
+            const float fd = (float)d;
+            for (int j = 0; j < 8; ++j) {
+                const int byte_idx = ih * 8 + j;
+                const int col = ib * 8 + byte_idx / 2;
+                const ulong q_offset = 2 * ((ulong)col * ne01 + r) + (byte_idx & 1);
+                const uint packed = q[q_offset];
+                dst_row[dst_base + 2*j + 0] = ((float)(packed & 0x0F) - 8.0f) * fd;
+                dst_row[dst_base + 2*j + 1] = ((float)(packed >> 4)   - 8.0f) * fd;
+            }
+        } else if (q4_0_layout == Q4_0_LAYOUT_ADRENO_MOE_TRANS4) {
+            global uchar * q = (global uchar *) src0;
+            global half * scales = (global half *) src0_d;
+            d = scales[(ulong)i02 * nb * ne01 + (ulong)ib * ne01 + r];
+            const float fd = (float)d;
+            for (int j = 0; j < 8; ++j) {
+                const int byte_idx = ih * 8 + j;
+                const int word_idx = byte_idx / 4;
+                const int byte_in_word = byte_idx & 3;
+                const ulong q_word_offset = ((ulong)i02 * nb * ne01 + (ulong)ib * ne01) * 4 + r + (ulong)word_idx * ne01;
+                const uint packed = q[4 * q_word_offset + byte_in_word];
+                dst_row[dst_base + 2*j + 0] = ((float)(packed & 0x0F) - 8.0f) * fd;
+                dst_row[dst_base + 2*j + 1] = ((float)(packed >> 4)   - 8.0f) * fd;
+            }
+        } else {
+            global uchar * q;
+            if (q4_0_layout == Q4_0_LAYOUT_SOA) {
+                global half * scales = (global half *) src0_d;
+                d = scales[row_block_offset + ib];
+                q = (global uchar *) src0 + (row_block_offset + ib) * (QK4_0 / 2);
+            } else {
+                global struct block_q4_0 * b = (global struct block_q4_0 *) ((global char *) src0 + row_byte_offset) + ib;
+                d = b->d;
+                q = (global uchar *) &b->qs[0];
+            }
+
+            const float fd = (float)d;
+            for (int j = 0; j < 8; ++j) {
+                uint packed;
+                if (ih == 0) {
+                    packed = (q[2*j + 0] & 0x0F) | ((q[2*j + 1] & 0x0F) << 4);
+                } else {
+                    packed = ((q[2*j + 0] & 0xF0) >> 4) | (q[2*j + 1] & 0xF0);
+                }
+                dst_row[dst_base + 2*j + 0] = ((float)(packed & 0x0F) - 8.0f) * fd;
+                dst_row[dst_base + 2*j + 1] = ((float)(packed >> 4)   - 8.0f) * fd;
+            }
         }
-        dequantize_q4_0_f32(
-            ((global struct block_q4_0 *) ((global char *) src0 + r*nb01 + i02*nb02 + i03*nb03)) + ind/NL, ind%NL, &temp);
-        *(((global float16 *) ((global char *) dst + i12*nb3 + i11*nb2 + i10*nb1)) + ind) = temp;
     }
 }

--- a/src/ggml-opencl/kernels/transpose.cl
+++ b/src/ggml-opencl/kernels/transpose.cl
@@ -118,26 +118,48 @@ kernel void kernel_transpose_32_16(__read_only image1d_buffer_t input, __write_o
     const int j = get_global_id(1);
     const int i_2 = i<<2;
     const int j_2 = j<<2;
-    half4 temp0 = {0,0,0,0}; // initialize outputs to 0
-    half4 temp1 = {0,0,0,0};
-    half4 temp2 = {0,0,0,0};
-    half4 temp3 = {0,0,0,0};
 
-    if((j_2+0)*cols+i*4+3 < rows*cols*16){ // only load from a valid location. Otherwise keep register data as 0
-        temp0 = read_imageh(input, (j_2+0)*cols+i);
-    }
-    if((j_2+1)*cols+i*4+3 < rows*cols*16){
-        temp1 = read_imageh(input, (j_2+1)*cols+i);
-    }
-    if((j_2+2)*cols+i*4+3 < rows*cols*16){
-        temp2 = read_imageh(input, (j_2+2)*cols+i);
-    }
-    if((j_2+3)*cols+i*4+3 < rows*cols*16){
-        temp3 = read_imageh(input, (j_2+3)*cols+i);
-    }
+    float4 temp0 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp1 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp2 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp3 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
 
-    write_imageh(output, (i_2+0)*padded_rows+j, (half4)(temp0.s0, temp1.s0, temp2.s0, temp3.s0)); // no conditionals for output, includes zero padding
-    write_imageh(output, (i_2+1)*padded_rows+j, (half4)(temp0.s1, temp1.s1, temp2.s1, temp3.s1));
-    write_imageh(output, (i_2+2)*padded_rows+j, (half4)(temp0.s2, temp1.s2, temp2.s2, temp3.s2));
-    write_imageh(output, (i_2+3)*padded_rows+j, (half4)(temp0.s3, temp1.s3, temp2.s3, temp3.s3));
+    if ((j_2 + 0) < rows) temp0 = read_imagef(input, (j_2 + 0)*cols + i);
+    if ((j_2 + 1) < rows) temp1 = read_imagef(input, (j_2 + 1)*cols + i);
+    if ((j_2 + 2) < rows) temp2 = read_imagef(input, (j_2 + 2)*cols + i);
+    if ((j_2 + 3) < rows) temp3 = read_imagef(input, (j_2 + 3)*cols + i);
+
+    write_imageh(output, (i_2+0)*padded_rows+j, convert_half4((float4)(temp0.s0, temp1.s0, temp2.s0, temp3.s0)));
+    write_imageh(output, (i_2+1)*padded_rows+j, convert_half4((float4)(temp0.s1, temp1.s1, temp2.s1, temp3.s1)));
+    write_imageh(output, (i_2+2)*padded_rows+j, convert_half4((float4)(temp0.s2, temp1.s2, temp2.s2, temp3.s2)));
+    write_imageh(output, (i_2+3)*padded_rows+j, convert_half4((float4)(temp0.s3, temp1.s3, temp2.s3, temp3.s3)));
+}
+
+// 32-bit transpose with optional zero padding, stores FP32 output.
+kernel void kernel_transpose_32_32(
+    __read_only image1d_buffer_t input,
+    __write_only image1d_buffer_t output,
+    const uint rows,
+    const uint cols,
+    const uint padded_rows
+) {
+    const int i = get_global_id(0);
+    const int j = get_global_id(1);
+    const int i_2 = i << 2;
+    const int j_2 = j << 2;
+
+    float4 temp0 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp1 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp2 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp3 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+
+    if ((j_2 + 0) < rows) temp0 = read_imagef(input, (j_2 + 0) * cols + i);
+    if ((j_2 + 1) < rows) temp1 = read_imagef(input, (j_2 + 1) * cols + i);
+    if ((j_2 + 2) < rows) temp2 = read_imagef(input, (j_2 + 2) * cols + i);
+    if ((j_2 + 3) < rows) temp3 = read_imagef(input, (j_2 + 3) * cols + i);
+
+    write_imagef(output, (i_2 + 0) * padded_rows + j, (float4)(temp0.s0, temp1.s0, temp2.s0, temp3.s0));
+    write_imagef(output, (i_2 + 1) * padded_rows + j, (float4)(temp0.s1, temp1.s1, temp2.s1, temp3.s1));
+    write_imagef(output, (i_2 + 2) * padded_rows + j, (float4)(temp0.s2, temp1.s2, temp2.s2, temp3.s2));
+    write_imagef(output, (i_2 + 3) * padded_rows + j, (float4)(temp0.s3, temp1.s3, temp2.s3, temp3.s3));
 }


### PR DESCRIPTION
## Summary

Fix OpenCL Q4_0 correctness issues seen when `GGML_OPENCL_SOA_Q` and Adreno OpenCL kernels are enabled:

- allow `GET_ROWS(Q4_0)` to read SOA quant buffers instead of assuming an AoS `block_q4_0` buffer
- handle Adreno-transposed and Adreno-MoE Q4_0 layouts in `GET_ROWS(Q4_0)`
- avoid a shared static temporary buffer in `transpose_2d()`
- fix the fused RMSNorm/MUL offset to use `src1->view_offs`
- preserve F32 activation/accumulation for selected Adreno Q4_0 GEMM paths that otherwise produce invalid diffusion output

The same fix was also prepared for the older `leejet/ggml` fork used by stable-diffusion.cpp, but this branch was re-applied and build-checked against upstream master.

## Image evidence

The image-level reproduction was run through stable-diffusion.cpp using ggml OpenCL, because the observed failure requires full diffusion-model execution.

Test device/config:

```text
QUALCOMM Adreno 830, OpenCL 3.0 QUALCOMM build: 0800.71 Compiler E031.47.18.49
GGML_OPENCL_SOA_Q=ON
GGML_OPENCL_USE_ADRENO_KERNELS=ON
VAE conv direct enabled
Diffusion flash attention disabled
```

Individual images:

| Case | Before | After |
| --- | --- | --- |
| Flux.2 Klein Q4_0, 512x512 | ![Klein before](https://gist.githubusercontent.com/happyyzy/e97c8d566fb155a59232a460dbe6f4cb/raw/klein_before_blank.png) | ![Klein after](https://gist.githubusercontent.com/happyyzy/e97c8d566fb155a59232a460dbe6f4cb/raw/klein_after_fixed.png) |
| Z-Image Turbo Q4_0, 512x512 | ![Z-Image before](https://gist.githubusercontent.com/happyyzy/e97c8d566fb155a59232a460dbe6f4cb/raw/zimage_before_blank.png) | ![Z-Image after](https://gist.githubusercontent.com/happyyzy/e97c8d566fb155a59232a460dbe6f4cb/raw/zimage_after_fixed.png) |

## Reproduction commands

The same model files and generation parameters were used before and after the patch.

### Flux.2 Klein Q4_0, before

```bash
git checkout 3af5f5760e19a96427f5f7a93b79cbdf3d4b265b
./bin/sd-cli \
  --diffusion-model "$KLEIN_Q4_0_GGUF" \
  --llm "$QWEN_3_4B_Q4_0_GGUF" \
  --vae "$FLUX2_VAE_SAFETENSORS" \
  -p "a lovely cat" \
  --cfg-scale 1.0 \
  --steps 4 \
  --seed 42 \
  -W 512 -H 512 \
  --vae-conv-direct \
  -o klein_before.png \
  -v
```

Result: command completes and saves an image, but the output is blank.

### Flux.2 Klein Q4_0, after

```bash
git checkout e30fbfe5
./bin/sd-cli \
  --diffusion-model "$KLEIN_Q4_0_GGUF" \
  --llm "$QWEN_3_4B_Q4_0_GGUF" \
  --vae "$FLUX2_VAE_SAFETENSORS" \
  -p "a lovely cat" \
  --cfg-scale 1.0 \
  --steps 4 \
  --seed 42 \
  -W 512 -H 512 \
  --vae-conv-direct \
  -o klein_after.png \
  -v
```

Result: valid image output.

### Z-Image Turbo Q4_0, before

```bash
git checkout 3af5f5760e19a96427f5f7a93b79cbdf3d4b265b
./bin/sd-cli \
  --diffusion-model "$Z_IMAGE_TURBO_Q4_0_GGUF" \
  --llm "$QWEN_3_4B_Q4_0_GGUF" \
  --vae "$Z_IMAGE_AE_SAFETENSORS" \
  -p "a lovely cat" \
  --cfg-scale 1.0 \
  --steps 8 \
  --seed 42 \
  -W 512 -H 512 \
  --vae-conv-direct \
  -o zimage_before.png \
  -v
```

Result: command completes and saves an image, but the output is blank.

### Z-Image Turbo Q4_0, after

```bash
git checkout e30fbfe5
./bin/sd-cli \
  --diffusion-model "$Z_IMAGE_TURBO_Q4_0_GGUF" \
  --llm "$QWEN_3_4B_Q4_0_GGUF" \
  --vae "$Z_IMAGE_AE_SAFETENSORS" \
  -p "a lovely cat wearing black sunglasses, studio photo" \
  --cfg-scale 1.0 \
  --steps 4 \
  --seed 42 \
  -W 512 -H 512 \
  --vae-conv-direct \
  -o zimage_after.png \
  -v
```

Result: valid image output.

## Checks

```bash
git diff --check ggmlorg/master..HEAD

cmake -S . -B /tmp/ggml_opencl_upstream_pr_build -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DGGML_OPENCL=ON \
  -DGGML_OPENCL_USE_ADRENO_KERNELS=ON \
  -DGGML_OPENCL_EMBED_KERNELS=ON \
  -DGGML_NATIVE=OFF

cmake --build /tmp/ggml_opencl_upstream_pr_build --target ggml -j
```

The OpenCL-enabled ggml target builds successfully on this branch.
