### PR TITLE
opencl: add Adreno xmem SDPA path

### DIFF
--- a/src/ggml-opencl/CMakeLists.txt
+++ b/src/ggml-opencl/CMakeLists.txt
@@ -212,6 +212,7 @@ set(GGML_OPENCL_KERNELS
 
 if (GGML_OPENCL_USE_ADRENO_KERNELS)
     list(APPEND GGML_OPENCL_KERNELS gemm_xmem_f16_f32_os8)
+    list(APPEND GGML_OPENCL_KERNELS sdpa_xmem_f32_f16_os8)
 endif ()
 
 foreach (K ${GGML_OPENCL_KERNELS})

--- a/src/ggml-opencl/ggml-opencl.cpp
+++ b/src/ggml-opencl/ggml-opencl.cpp
@@ -593,6 +593,7 @@ struct ggml_backend_opencl_context {
     ggml_cl_buffer prealloc_src1;
 
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+    std::mutex transpose_2d_mutex;
     ggml_cl_buffer prealloc_adreno_xmem_const;
     bool adreno_xmem_gemm_enabled = false;
 #endif
@@ -989,6 +990,7 @@ struct ggml_backend_opencl_context {
     cl_program program_transpose;
 
     cl_kernel kernel_transpose_32;
+    cl_kernel kernel_transpose_32_32;
     cl_kernel kernel_transpose_32_16;
     cl_kernel kernel_transpose_16;
     cl_kernel kernel_transpose_8_buf;
@@ -998,6 +1000,7 @@ struct ggml_backend_opencl_context {
 
     // Gemm and Gemv related programs, kernels, etc
     cl_kernel kernel_gemm_noshuffle_q4_0_f32;
+    cl_kernel kernel_gemm_noshuffle_q4_0_f32_f32act;
     cl_kernel kernel_gemv_noshuffle_q4_0_f32;
     cl_kernel kernel_gemv_noshuffle_q4_0_f32_4096_1_11008;
     cl_kernel kernel_gemv_noshuffle_q4_0_f32_4096_1_4096;
@@ -3210,6 +3213,7 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx) {
             build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
 
         CL_CHECK((backend_ctx->kernel_transpose_32_16 = clCreateKernel(backend_ctx->program_transpose, "kernel_transpose_32_16", &err), err));
+        CL_CHECK((backend_ctx->kernel_transpose_32_32 = clCreateKernel(backend_ctx->program_transpose, "kernel_transpose_32_32", &err), err));
         CL_CHECK((backend_ctx->kernel_transpose_32    = clCreateKernel(backend_ctx->program_transpose, "kernel_transpose_32", &err), err));
         CL_CHECK((backend_ctx->kernel_transpose_16    = clCreateKernel(backend_ctx->program_transpose, "kernel_transpose_16", &err), err));
         CL_CHECK((backend_ctx->kernel_transpose_8_buf  = clCreateKernel(backend_ctx->program_transpose, "kernel_transpose_8_buf", &err), err));
@@ -3374,6 +3378,11 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx) {
 #endif
         cl_program prog = build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src_CL_gemm.c_str(), compile_opts);
         CL_CHECK((backend_ctx->kernel_gemm_noshuffle_q4_0_f32 = clCreateKernel(prog, "kernel_gemm_noshuffle_q4_0_f32", &err), err));
+        CL_CHECK(clReleaseProgram(prog));
+
+        std::string compile_opts_f32act = compile_opts + " -DUSE_F32_ACT=1";
+        prog = build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src_CL_gemm.c_str(), compile_opts_f32act);
+        CL_CHECK((backend_ctx->kernel_gemm_noshuffle_q4_0_f32_f32act = clCreateKernel(prog, "kernel_gemm_noshuffle_q4_0_f32", &err), err));
         CL_CHECK(clReleaseProgram(prog));
         GGML_LOG_CONT(".");
     }
@@ -5623,7 +5632,7 @@ static void transpose_2d(
     cl_int stride, cl_int rows,
     bool blocking = true
 ) {
-    static ggml_cl_buffer buf;
+    ggml_cl_buffer buf;
 
     cl_event evt;
     cl_int err;
@@ -5638,6 +5647,8 @@ static void transpose_2d(
     CL_CHECK((trans = clCreateSubBuffer(
         buf.buffer, CL_MEM_READ_WRITE,
         CL_BUFFER_CREATE_TYPE_REGION, &region, &err), err));
+
+    std::lock_guard<std::mutex> lock(backend_ctx->transpose_2d_mutex);
 
     CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &src));
     CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &trans));
@@ -6434,6 +6445,15 @@ inline bool use_adreno_kernels(const ggml_backend_opencl_context *backend_ctx, c
     return threashold_ok;
 }
 
+static inline bool use_adreno_q4_0_f32_activation_gemm(const ggml_tensor * tensor) {
+    if (tensor == nullptr || tensor->type != GGML_TYPE_Q4_0 || tensor->name[0] == '\0') {
+        return false;
+    }
+
+    return strstr(tensor->name, "attention.qkv.weight") != nullptr ||
+           strstr(tensor->name, "attention.out.weight") != nullptr;
+}
+
 inline bool use_adreno_moe_kernels(const ggml_backend_opencl_context *backend_ctx, const ggml_tensor *tensor) {
     GGML_UNUSED(backend_ctx);
     int ne01 = tensor->ne[1];
@@ -6454,6 +6474,20 @@ static inline bool use_flat_gemv_for_large_m_q4_K(const ggml_tensor *tensor) {
     // threshold is well above typical hidden/FFN dims, but below typical vocab sizes.
     // note that this forces large M weights to use LM GEMM.
     return tensor->ne[1] >= 32768 && tensor->ne[2] == 1 && tensor->ne[3] == 1;
+}
+
+static inline bool opencl_uses_soa_quant_extra(enum ggml_type type) {
+#ifdef GGML_OPENCL_SOA_Q
+    return type == GGML_TYPE_Q4_0  || type == GGML_TYPE_Q4_1 ||
+           type == GGML_TYPE_Q5_0  || type == GGML_TYPE_Q5_1 ||
+           type == GGML_TYPE_Q8_0  || type == GGML_TYPE_IQ4_NL ||
+           type == GGML_TYPE_MXFP4 ||
+           type == GGML_TYPE_Q4_K  || type == GGML_TYPE_Q5_K ||
+           type == GGML_TYPE_Q6_K;
+#else
+    GGML_UNUSED(type);
+    return false;
+#endif
 }
 
 static inline bool use_flat_gemv_for_large_m_q6_K(const ggml_tensor *tensor) {
@@ -6495,12 +6529,7 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                 case GGML_TYPE_F16:
                     return true;
                 case GGML_TYPE_Q4_0:
-#ifdef GGML_OPENCL_SOA_Q
-                    // We do not support flattened Q4_0 (and possibly other Q's)
-                    return false;
-#else // GGML_OPENCL_SOA_Q
                     return true;
-#endif // GGML_OPENCL_SOA_Q
                 default:
                     return false;
             }
@@ -7491,7 +7520,8 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
         // Adreno moe q4_0 kernel needs special transpose and unshuffling
         if (use_adreno_moe_kernels(backend_ctx, tensor)) {
-            cl_kernel kernel = backend_ctx->kernel_convert_block_q4_0_trans4_ns;
+            cl_kernel kernel;
+            CL_CHECK((kernel = clCreateKernel(backend_ctx->program_cvt, "kernel_convert_block_q4_0_trans4_ns", &err), err));
 
             int ne00 = tensor->ne[0];
             int ne01 = tensor->ne[1];
@@ -7508,6 +7538,7 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
             cl_event evt;
             CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
             CL_CHECK(clWaitForEvents(1, &evt));
+            CL_CHECK(clReleaseKernel(kernel));
             CL_CHECK(clReleaseMemObject(data_device));
 
             // Create image for Q
@@ -7528,15 +7559,17 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
 
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
-        cl_kernel kernel = backend_ctx->kernel_convert_block_q4_0;
+        const char * kernel_name = "kernel_convert_block_q4_0";
 
         // The optimized kernels need weights in natural order, so unshuffle.
         if (use_adreno_kernels(backend_ctx, tensor)) {
-            kernel = backend_ctx->kernel_convert_block_q4_0_noshuffle;
+            kernel_name = "kernel_convert_block_q4_0_noshuffle";
         }
 #else
-        cl_kernel kernel = backend_ctx->kernel_convert_block_q4_0;
+        const char * kernel_name = "kernel_convert_block_q4_0";
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
+        cl_kernel kernel;
+        CL_CHECK((kernel = clCreateKernel(backend_ctx->program_cvt, kernel_name, &err), err));
         CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &data_device));
         CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->q));
         CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->d));
@@ -7547,6 +7580,7 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         cl_event evt;
         CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
         CL_CHECK(clWaitForEvents(1, &evt));
+        CL_CHECK(clReleaseKernel(kernel));
         CL_CHECK(clReleaseMemObject(data_device));
 
         tensor->extra = extra;
@@ -7557,7 +7591,7 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         // Only do transpose for large, non batched matrix
         // TODO: use preallocated images instead of sub-buffer then image
         if (use_adreno_kernels(backend_ctx, tensor)) {
-        int M = tensor->ne[1];
+            int M = tensor->ne[1];
             int K = tensor->ne[0];
 
             GGML_ASSERT(K % 32 == 0);
@@ -10449,11 +10483,10 @@ static void ggml_cl_get_rows(ggml_backend_t backend, const ggml_tensor * src0, c
 
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
 
-    ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
     ggml_tensor_extra_cl * extra1 = (ggml_tensor_extra_cl *)src1->extra;
     ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
 
-    cl_ulong offset0 = extra0->offset + src0->view_offs;
+    cl_ulong offset0 = 0;
     cl_ulong offset1 = extra1->offset + src1->view_offs;
     cl_ulong offsetd = extrad->offset + dst->view_offs;
 
@@ -10473,7 +10506,33 @@ static void ggml_cl_get_rows(ggml_backend_t backend, const ggml_tensor * src0, c
             GGML_ASSERT(false && "not implemented");
     }
 
-    CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0->data_device));
+    cl_mem src0_data_device = nullptr;
+    cl_mem src0_q4_0_d_device = nullptr;
+    int q4_0_layout = 0;
+    int q4_0_ne01 = src0->ne[1];
+
+#ifdef GGML_OPENCL_SOA_Q
+    if (src0->type == GGML_TYPE_Q4_0) {
+        ggml_tensor_extra_cl_q4_0 * extra0_q4_0 = (ggml_tensor_extra_cl_q4_0 *)src0->extra;
+        src0_data_device = extra0_q4_0->q;
+        src0_q4_0_d_device = extra0_q4_0->d;
+        q4_0_layout = 1;
+#ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+        if (use_adreno_moe_kernels(backend_ctx, src0)) {
+            q4_0_layout = 3;
+        } else if (use_adreno_kernels(backend_ctx, src0)) {
+            q4_0_layout = 2;
+        }
+#endif
+    }
+#endif
+    if (src0_data_device == nullptr) {
+        ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
+        offset0 = extra0->offset + src0->view_offs;
+        src0_data_device = extra0->data_device;
+        src0_q4_0_d_device = src0_data_device;
+    }
+    CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &src0_data_device));
     CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_ulong), &offset0));
     CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra1->data_device));
     CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_ulong), &offset1));
@@ -10490,6 +10549,11 @@ static void ggml_cl_get_rows(ggml_backend_t backend, const ggml_tensor * src0, c
     CL_CHECK(clSetKernelArg(kernel, 14, sizeof(cl_ulong), &nb1));
     CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_ulong), &nb2));
     CL_CHECK(clSetKernelArg(kernel, 16, sizeof(cl_ulong), &nb3));
+    if (src0->type == GGML_TYPE_Q4_0) {
+        CL_CHECK(clSetKernelArg(kernel, 17, sizeof(cl_mem), &src0_q4_0_d_device));
+        CL_CHECK(clSetKernelArg(kernel, 18, sizeof(int),    &q4_0_layout));
+        CL_CHECK(clSetKernelArg(kernel, 19, sizeof(int),    &q4_0_ne01));
+    }
 
     int max_workgroup_size = backend_ctx->get_kernel_workgroup_size(kernel);
     int nth = 1;
@@ -12051,7 +12115,7 @@ static void ggml_opencl_op_rms_norm_fused(ggml_backend_t backend, ggml_tensor * 
     ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
 
     cl_ulong offset0 = extra0->offset + src0->view_offs;
-    cl_ulong offset1 = extra1->offset + src0->view_offs;
+    cl_ulong offset1 = extra1->offset + src1->view_offs;
     cl_ulong offsetd = extrad->offset + dst->view_offs;
 
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
@@ -15270,15 +15334,16 @@ static void ggml_cl_mul_mat_q4_0_f32_adreno(ggml_backend_t backend, const ggml_t
         if (extra_elements > 0){
             padding = 8 - extra_elements;
         }
+        const bool use_f32_act = use_adreno_q4_0_f32_activation_gemm(src0);
 
         // subbuffer for transposed activations
         region.origin = 0;
-        region.size = K * (N + padding) * sizeof(float)/2;
+        region.size = K * (N + padding) * (use_f32_act ? sizeof(float) : sizeof(float)/2);
         backend_ctx->prealloc_act_trans.allocate(context, region.size);
         CL_CHECK((b_sub_buf_trans = clCreateSubBuffer(backend_ctx->prealloc_act_trans.buffer, 0, CL_BUFFER_CREATE_TYPE_REGION, &region, &err), err));
 
         // image for transposed activations
-        img_fmt = {CL_RGBA, CL_HALF_FLOAT};
+        img_fmt = {CL_RGBA, static_cast<cl_channel_type>(use_f32_act ? CL_FLOAT : CL_HALF_FLOAT)};
         memset(&img_desc, 0, sizeof(img_desc));
         img_desc.image_type = CL_MEM_OBJECT_IMAGE1D_BUFFER;
         img_desc.image_width = K * (N + padding) / 4;
@@ -15298,15 +15363,22 @@ static void ggml_cl_mul_mat_q4_0_f32_adreno(ggml_backend_t backend, const ggml_t
         int width_B = K/4;
         int padded_height_B = (N + padding)/4;
 
-        kernel = backend_ctx->kernel_transpose_32_16;
+        if (use_f32_act) {
+            kernel = padding == 0 ? backend_ctx->kernel_transpose_32 : backend_ctx->kernel_transpose_32_32;
+        } else {
+            kernel = backend_ctx->kernel_transpose_32_16;
+        }
         CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &b_img));
         CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &b_img_trans));
-        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(int),    &height_B));
+        const int transpose_rows = (use_f32_act && padding == 0) ? height_B : N;
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(int),    &transpose_rows));
         CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int),    &width_B));
-        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int),    &padded_height_B));
+        if (!use_f32_act || padding != 0) {
+            CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int), &padded_height_B));
+        }
 
         size_t local_work_size_t[2] = { 1, 16 };
-        size_t global_work_size_t[2] = { (size_t)width_B, (size_t)padded_height_B };
+        size_t global_work_size_t[2] = { (size_t)width_B, (size_t)((use_f32_act && padding == 0) ? height_B : padded_height_B) };
         if (ne0 == 4096 && ne1 == 128 && ne10 == 4096) {
             local_work_size_t[0]=4;
             local_work_size_t[1]=8;
@@ -15323,7 +15395,7 @@ static void ggml_cl_mul_mat_q4_0_f32_adreno(ggml_backend_t backend, const ggml_t
         backend_ctx->enqueue_ndrange_kernel(kernel, 2, global_work_size_t, local_work_size_t, dst);
 
         // gemm
-        kernel = backend_ctx->kernel_gemm_noshuffle_q4_0_f32;
+        kernel = use_f32_act ? backend_ctx->kernel_gemm_noshuffle_q4_0_f32_f32act : backend_ctx->kernel_gemm_noshuffle_q4_0_f32;
         int padded_N = N + padding;
 
         CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra0_q4_0->q));
@@ -17234,11 +17306,15 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
         return;
     }
 
-    ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
+    ggml_tensor_extra_cl * extra0 = nullptr;
     ggml_tensor_extra_cl * extra1 = (ggml_tensor_extra_cl *)src1->extra;
     ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
 
-    cl_ulong offset0 = extra0->offset + src0->view_offs;
+    cl_ulong offset0 = 0;
+    if (!opencl_uses_soa_quant_extra(src0->type)) {
+        extra0 = (ggml_tensor_extra_cl *)src0->extra;
+        offset0 = extra0->offset + src0->view_offs;
+    }
     cl_ulong offset1 = extra1->offset + src1->view_offs;
     cl_ulong offsetd = extrad->offset + dst->view_offs;
 
@@ -19403,12 +19479,16 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
 
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
 
-    ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
+    ggml_tensor_extra_cl * extra0 = nullptr;
     ggml_tensor_extra_cl * extra1 = (ggml_tensor_extra_cl *)src1->extra;
     ggml_tensor_extra_cl * extra2 = (ggml_tensor_extra_cl *)src2->extra;
     ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
 
-    cl_ulong offset0 = extra0->offset + src0->view_offs;
+    cl_ulong offset0 = 0;
+    if (!opencl_uses_soa_quant_extra(src0->type)) {
+        extra0 = (ggml_tensor_extra_cl *)src0->extra;
+        offset0 = extra0->offset + src0->view_offs;
+    }
     cl_ulong offset1 = extra1->offset + src1->view_offs;
     cl_ulong offset2 = extra2->offset + src2->view_offs;
     cl_ulong offsetd = extrad->offset + dst->view_offs;

--- a/src/ggml-opencl/ggml-opencl.cpp
+++ b/src/ggml-opencl/ggml-opencl.cpp
@@ -504,6 +504,52 @@ struct ggml_opencl_fa_kernels {
     std::set<std::pair<int, std::pair<int, int>>> variant_attempted;
 };
 
+#ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+struct ggml_cl_adreno_xmem_attn_scratch {
+    cl_mem q_img = nullptr;
+    cl_mem k_img = nullptr;
+    cl_mem v_img = nullptr;
+    cl_mem out_img = nullptr;
+    cl_mem k_transpose_buf = nullptr;
+    cl_mem k_transpose_img1d = nullptr;
+    cl_mem k_packed_buf = nullptr;
+    cl_mem v_packed_buf = nullptr;
+    cl_mem score_buf = nullptr;
+    cl_mem prob_buf = nullptr;
+    cl_mem score_img1d = nullptr;
+    cl_mem prob_img1d = nullptr;
+    cl_mem softmax_stats_img2d = nullptr;
+    cl_mem xmem_qk = nullptr;
+    cl_mem xmem_pv = nullptr;
+
+    int n_q = 0;
+    int n_kv = 0;
+    int d_head_q = 0;
+    int d_head_v = 0;
+    int heads_total = 0;
+};
+
+struct ggml_cl_adreno_xmem_attn_state {
+    bool compiled = false;
+
+    cl_kernel kernel_q_f32_to_img_scaled = nullptr;
+    cl_kernel kernel_kv_f16_to_img_gqa = nullptr;
+    cl_kernel kernel_img_to_f32 = nullptr;
+    cl_kernel kernel_k_gather = nullptr;
+    cl_kernel kernel_pack_k = nullptr;
+    cl_kernel kernel_qk_gemm = nullptr;
+    cl_kernel kernel_softmax_reduce_basic = nullptr;
+    cl_kernel kernel_softmax_apply_basic = nullptr;
+    cl_kernel kernel_pack_v = nullptr;
+    cl_kernel kernel_pv_gemm = nullptr;
+
+    ggml_cl_adreno_xmem_attn_scratch scratch;
+};
+
+static void ggml_cl_adreno_xmem_attn_release_scratch(ggml_backend_opencl_context * backend_ctx);
+static void ggml_cl_adreno_xmem_attn_release_graph_score_storage(ggml_backend_opencl_context * backend_ctx);
+#endif
+
 // backend context
 struct ggml_backend_opencl_context {
     int ref_count;
@@ -596,6 +642,7 @@ struct ggml_backend_opencl_context {
     std::mutex transpose_2d_mutex;
     ggml_cl_buffer prealloc_adreno_xmem_const;
     bool adreno_xmem_gemm_enabled = false;
+    ggml_cl_adreno_xmem_attn_state adreno_xmem_attn;
 #endif
 
     // prealloc buffers for MoE router table preprocess
@@ -2140,6 +2187,44 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx) {
         CL_CHECK((backend_ctx->kernel_adreno_xmem_store_dst_f32 =
             clCreateKernel(prog, "adreno_xmem_store_dst_f32", &err), err));
         CL_CHECK(clReleaseProgram(prog));
+        GGML_LOG_CONT(".");
+    }
+
+    // sdpa_xmem_f32_f16_os8
+    if (backend_ctx->gpu_family == GPU_FAMILY::ADRENO) {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src {
+            #include "sdpa_xmem_f32_f16_os8.cl.h"
+        };
+#else
+        const std::string kernel_src = read_file("sdpa_xmem_f32_f16_os8.cl");
+#endif
+        cl_program prog =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+
+        auto & xmem_attn = backend_ctx->adreno_xmem_attn;
+        CL_CHECK((xmem_attn.kernel_q_f32_to_img_scaled =
+            clCreateKernel(prog, "adreno_xmem_attn_q_f32_to_img_scaled", &err), err));
+        CL_CHECK((xmem_attn.kernel_kv_f16_to_img_gqa =
+            clCreateKernel(prog, "adreno_xmem_attn_kv_f16_to_img_gqa", &err), err));
+        CL_CHECK((xmem_attn.kernel_img_to_f32 =
+            clCreateKernel(prog, "adreno_xmem_attn_img_to_f32", &err), err));
+        CL_CHECK((xmem_attn.kernel_k_gather =
+            clCreateKernel(prog, "adreno_xmem_attn_k_gather", &err), err));
+        CL_CHECK((xmem_attn.kernel_pack_k =
+            clCreateKernel(prog, "adreno_xmem_attn_pack_k", &err), err));
+        CL_CHECK((xmem_attn.kernel_qk_gemm =
+            clCreateKernel(prog, "adreno_xmem_attn_qk_gemm", &err), err));
+        CL_CHECK((xmem_attn.kernel_softmax_reduce_basic =
+            clCreateKernel(prog, "adreno_xmem_attn_softmax_reduce_basic", &err), err));
+        CL_CHECK((xmem_attn.kernel_softmax_apply_basic =
+            clCreateKernel(prog, "adreno_xmem_attn_softmax_apply_basic", &err), err));
+        CL_CHECK((xmem_attn.kernel_pack_v =
+            clCreateKernel(prog, "adreno_xmem_attn_pack_v", &err), err));
+        CL_CHECK((xmem_attn.kernel_pv_gemm =
+            clCreateKernel(prog, "adreno_xmem_attn_pv_gemm", &err), err));
+        CL_CHECK(clReleaseProgram(prog));
+        xmem_attn.compiled = true;
         GGML_LOG_CONT(".");
     }
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
@@ -6273,6 +6358,10 @@ static void ggml_backend_opencl_synchronize(ggml_backend_t backend) {
     CL_CHECK(clEnqueueBarrierWithWaitList(backend_ctx->queue, 0, nullptr, &evt));
     CL_CHECK(clWaitForEvents(1, &evt));
     CL_CHECK(clReleaseEvent(evt));
+
+#ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+    ggml_cl_adreno_xmem_attn_release_graph_score_storage(backend_ctx);
+#endif
 }
 
 // Synchronizes the 'backend_ctx's device with others so that commands
@@ -13684,6 +13773,544 @@ static constexpr int FD_MAX_N_Q_MULTI = 8;
 static constexpr int FD_MQ_KV_PER_SPLIT = 256;
 static constexpr int FD_MQ_MAX_SPLITS   = 128;
 
+#ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+struct ggml_cl_adreno_xmem_attn_schedule {
+    int qk_lws0 = 256;
+    int qk_lws2 = 1;
+    int softmax_reduce_lws0 = 256;
+    int softmax_apply_lws0 = 64;
+    int softmax_apply_lws2 = 4;
+    int pv_lws0 = 64;
+    int pv_lws2 = 4;
+};
+
+static inline size_t ggml_cl_round_up(size_t x, size_t a) {
+    return ((x + a - 1) / a) * a;
+}
+
+static inline int ggml_cl_round_up_div(int x, int y) {
+    return (x + y - 1) / y;
+}
+
+static inline void ggml_cl_set_arg_int4(cl_kernel kernel, cl_uint index, int x, int y, int z, int w) {
+    struct { int x, y, z, w; } value { x, y, z, w };
+    CL_CHECK(clSetKernelArg(kernel, index, sizeof(value), &value));
+}
+
+static cl_mem ggml_cl_make_image2d_half4(cl_context context, cl_mem_flags flags, size_t width, size_t height) {
+    cl_int err = CL_SUCCESS;
+    cl_image_format format = { CL_RGBA, CL_HALF_FLOAT };
+    cl_image_desc desc = {};
+    desc.image_type = CL_MEM_OBJECT_IMAGE2D;
+    desc.image_width = width;
+    desc.image_height = height;
+    cl_mem image = clCreateImage(context, flags, &format, &desc, nullptr, &err);
+    CL_CHECK(err);
+    return image;
+}
+
+static cl_mem ggml_cl_make_image1d_buffer_half4(cl_context context, cl_mem_flags flags, size_t width, cl_mem backing_buffer) {
+    cl_int err = CL_SUCCESS;
+    cl_image_format format = { CL_RGBA, CL_HALF_FLOAT };
+    cl_image_desc desc = {};
+    desc.image_type = CL_MEM_OBJECT_IMAGE1D_BUFFER;
+    desc.image_width = width;
+    desc.buffer = backing_buffer;
+    cl_mem image = clCreateImage(context, flags, &format, &desc, nullptr, &err);
+    CL_CHECK(err);
+    return image;
+}
+
+static void ggml_cl_release_mem(cl_mem & mem) {
+    if (mem != nullptr) {
+        CL_CHECK(clReleaseMemObject(mem));
+        mem = nullptr;
+    }
+}
+
+static void ggml_cl_adreno_xmem_attn_barrier(ggml_backend_opencl_context * backend_ctx) {
+    CL_CHECK(clEnqueueBarrierWithWaitList(backend_ctx->queue, 0, nullptr, nullptr));
+}
+
+static void ggml_cl_adreno_xmem_attn_release_scratch(ggml_backend_opencl_context * backend_ctx) {
+    auto & s = backend_ctx->adreno_xmem_attn.scratch;
+    ggml_cl_release_mem(s.q_img);
+    ggml_cl_release_mem(s.k_img);
+    ggml_cl_release_mem(s.v_img);
+    ggml_cl_release_mem(s.out_img);
+    ggml_cl_release_mem(s.k_transpose_img1d);
+    ggml_cl_release_mem(s.k_transpose_buf);
+    ggml_cl_release_mem(s.k_packed_buf);
+    ggml_cl_release_mem(s.v_packed_buf);
+    ggml_cl_release_mem(s.score_img1d);
+    ggml_cl_release_mem(s.prob_img1d);
+    ggml_cl_release_mem(s.score_buf);
+    ggml_cl_release_mem(s.prob_buf);
+    ggml_cl_release_mem(s.softmax_stats_img2d);
+    ggml_cl_release_mem(s.xmem_qk);
+    ggml_cl_release_mem(s.xmem_pv);
+    s = {};
+}
+
+static void ggml_cl_adreno_xmem_attn_release_graph_score_storage(ggml_backend_opencl_context * backend_ctx) {
+    auto & s = backend_ctx->adreno_xmem_attn.scratch;
+    ggml_cl_release_mem(s.score_img1d);
+    ggml_cl_release_mem(s.prob_img1d);
+    ggml_cl_release_mem(s.score_buf);
+    ggml_cl_release_mem(s.prob_buf);
+}
+
+static ggml_cl_adreno_xmem_attn_schedule ggml_cl_adreno_xmem_attn_select_schedule(
+        const ggml_backend_opencl_context * backend_ctx,
+        int n_q,
+        int n_kv,
+        int heads_total) {
+    const bool big_h = heads_total >= 8;
+    ggml_cl_adreno_xmem_attn_schedule sched;
+
+    if (n_q >= 512) sched.qk_lws0 = 512;
+    else if (n_q >= 256) sched.qk_lws0 = 128;
+    else sched.qk_lws0 = 64;
+    sched.qk_lws2 = (big_h && n_q >= 512) ? 2 : 1;
+
+    if (n_kv >= 2048) sched.softmax_reduce_lws0 = 1024;
+    else if (n_kv >= 512) sched.softmax_reduce_lws0 = big_h ? 256 : 512;
+    else sched.softmax_reduce_lws0 = 256;
+
+    if (n_kv < 256) sched.softmax_apply_lws0 = 64;
+    else sched.softmax_apply_lws0 = big_h ? 128 : 64;
+    sched.softmax_apply_lws2 = n_kv >= 512 ? 8 : 4;
+
+    if (n_q < 256) sched.pv_lws0 = 64;
+    else sched.pv_lws0 = big_h ? 128 : 64;
+    sched.pv_lws2 = big_h ? 8 : (n_q <= 256 ? 8 : 4);
+
+    const int max_wg = (int) backend_ctx->max_workgroup_size;
+    auto fix = [&](int & l0, int & l2) {
+        while (l0 * l2 > max_wg) {
+            if (l2 > 1) l2 /= 2;
+            else if (l0 > 32) l0 /= 2;
+            else break;
+        }
+    };
+    fix(sched.qk_lws0, sched.qk_lws2);
+    fix(sched.softmax_apply_lws0, sched.softmax_apply_lws2);
+    fix(sched.pv_lws0, sched.pv_lws2);
+    while (sched.softmax_reduce_lws0 > max_wg) {
+        sched.softmax_reduce_lws0 /= 2;
+    }
+
+    return sched;
+}
+
+static void ggml_cl_adreno_xmem_attn_make_tail_mask(int n, ggml_fp16_t out[4]) {
+    float actual[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    const int rem = n & 3;
+    if (rem != 0) {
+        for (int i = rem; i < 4; ++i) {
+            actual[i] = 0.0f;
+        }
+    }
+    out[0] = ggml_fp32_to_fp16(actual[3]);
+    out[1] = ggml_fp32_to_fp16(actual[0]);
+    out[2] = ggml_fp32_to_fp16(actual[1]);
+    out[3] = ggml_fp32_to_fp16(actual[2]);
+}
+
+static bool ggml_cl_adreno_xmem_attn_prepare(
+        ggml_backend_opencl_context * backend_ctx,
+        int n_q,
+        int n_kv,
+        int d_head_q,
+        int d_head_v,
+        int heads_total) {
+    auto & s = backend_ctx->adreno_xmem_attn.scratch;
+    if (s.q_img != nullptr &&
+            s.n_q == n_q &&
+            s.n_kv == n_kv &&
+            s.d_head_q == d_head_q &&
+            s.d_head_v == d_head_v &&
+            s.heads_total == heads_total) {
+        const int npack = ggml_cl_round_up_div(n_kv, 4);
+        const size_t score_half4_elems = (size_t) npack * heads_total * n_q;
+        const size_t score_bytes = score_half4_elems * sizeof(uint16_t) * 4;
+        if (s.score_buf == nullptr) {
+            s.score_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, score_bytes, nullptr, nullptr);
+            GGML_ASSERT(s.score_buf != nullptr);
+            s.score_img1d = ggml_cl_make_image1d_buffer_half4(backend_ctx->context, CL_MEM_READ_ONLY, score_half4_elems, s.score_buf);
+        }
+        if (s.prob_buf == nullptr) {
+            s.prob_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, score_bytes, nullptr, nullptr);
+            GGML_ASSERT(s.prob_buf != nullptr);
+            s.prob_img1d = ggml_cl_make_image1d_buffer_half4(backend_ctx->context, CL_MEM_READ_ONLY, score_half4_elems, s.prob_buf);
+        }
+        return true;
+    }
+
+    ggml_cl_adreno_xmem_attn_release_scratch(backend_ctx);
+
+    const int qpack = d_head_q / 4;
+    const int vpack = d_head_v / 4;
+    const int npack = ggml_cl_round_up_div(n_kv, 4);
+    const size_t q_img_h = (size_t) heads_total * qpack;
+    const size_t v_img_h = (size_t) heads_total * vpack;
+
+    s.q_img = ggml_cl_make_image2d_half4(backend_ctx->context, CL_MEM_READ_WRITE, (size_t) n_q, q_img_h);
+    s.k_img = ggml_cl_make_image2d_half4(backend_ctx->context, CL_MEM_READ_WRITE, (size_t) n_kv, q_img_h);
+    s.v_img = ggml_cl_make_image2d_half4(backend_ctx->context, CL_MEM_READ_WRITE, (size_t) n_kv, v_img_h);
+    s.out_img = ggml_cl_make_image2d_half4(backend_ctx->context, CL_MEM_READ_WRITE, (size_t) n_q, v_img_h);
+
+    const size_t k_transpose_half4_elems = (size_t) npack * heads_total * d_head_q;
+    s.k_transpose_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, k_transpose_half4_elems * sizeof(uint16_t) * 4, nullptr, nullptr);
+    GGML_ASSERT(s.k_transpose_buf != nullptr);
+    s.k_transpose_img1d = ggml_cl_make_image1d_buffer_half4(backend_ctx->context, CL_MEM_READ_ONLY, k_transpose_half4_elems, s.k_transpose_buf);
+
+    const size_t k_groups16 = (size_t) ggml_cl_round_up_div(heads_total * d_head_q, 16);
+    const size_t v_groups16 = (size_t) ggml_cl_round_up_div(heads_total * d_head_v, 16);
+    const size_t k_packed_half4_elems = (size_t) n_kv * k_groups16 * 4;
+    const size_t v_packed_half4_elems = (size_t) n_kv * v_groups16 * 4;
+    s.k_packed_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, k_packed_half4_elems * sizeof(uint16_t) * 4, nullptr, nullptr);
+    s.v_packed_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, v_packed_half4_elems * sizeof(uint16_t) * 4, nullptr, nullptr);
+    GGML_ASSERT(s.k_packed_buf != nullptr && s.v_packed_buf != nullptr);
+
+    const size_t score_half4_elems = (size_t) npack * heads_total * n_q;
+    const size_t score_bytes = score_half4_elems * sizeof(uint16_t) * 4;
+    s.score_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, score_bytes, nullptr, nullptr);
+    s.prob_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, score_bytes, nullptr, nullptr);
+    GGML_ASSERT(s.score_buf != nullptr && s.prob_buf != nullptr);
+    s.score_img1d = ggml_cl_make_image1d_buffer_half4(backend_ctx->context, CL_MEM_READ_ONLY, score_half4_elems, s.score_buf);
+    s.prob_img1d = ggml_cl_make_image1d_buffer_half4(backend_ctx->context, CL_MEM_READ_ONLY, score_half4_elems, s.prob_buf);
+    s.softmax_stats_img2d = ggml_cl_make_image2d_half4(backend_ctx->context, CL_MEM_READ_WRITE, (size_t) n_q, (size_t) heads_total);
+    s.xmem_qk = clCreateBuffer(backend_ctx->context, CL_MEM_READ_ONLY, 6144, nullptr, nullptr);
+    s.xmem_pv = clCreateBuffer(backend_ctx->context, CL_MEM_READ_ONLY, 6144, nullptr, nullptr);
+    GGML_ASSERT(s.softmax_stats_img2d != nullptr && s.xmem_qk != nullptr && s.xmem_pv != nullptr);
+
+    s.n_q = n_q;
+    s.n_kv = n_kv;
+    s.d_head_q = d_head_q;
+    s.d_head_v = d_head_v;
+    s.heads_total = heads_total;
+    return true;
+}
+
+static bool ggml_cl_adreno_xmem_attn_can_use(
+        const ggml_backend_opencl_context * backend_ctx,
+        const ggml_tensor * q,
+        const ggml_tensor * k,
+        const ggml_tensor * dst) {
+    const ggml_tensor * v = dst->src[2];
+    const ggml_tensor * mask = dst->src[3];
+    const ggml_tensor * sinks = dst->src[4];
+
+    if (!backend_ctx->adreno_xmem_attn.compiled || backend_ctx->gpu_family != GPU_FAMILY::ADRENO) {
+        return false;
+    }
+    if (q->type != GGML_TYPE_F32 || k->type != GGML_TYPE_F16 || v->type != GGML_TYPE_F16 || dst->type != GGML_TYPE_F32) {
+        return false;
+    }
+    if (mask != nullptr || sinks != nullptr) {
+        return false;
+    }
+    if (q->nb[0] != ggml_type_size(q->type) || k->nb[0] != ggml_type_size(k->type) ||
+        v->nb[0] != ggml_type_size(v->type) || dst->nb[0] != ggml_type_size(dst->type)) {
+        return false;
+    }
+
+    const int n_q = q->ne[1];
+    const int n_kv = k->ne[1];
+    const int d_head_q = q->ne[0];
+    const int d_head_v = v->ne[0];
+    const int n_head = q->ne[2];
+    const int n_head_kv = k->ne[2];
+    const int n_batch = q->ne[3];
+
+    if (n_q <= 1 || n_q != n_kv) {
+        return false;
+    }
+    if (d_head_q != k->ne[0] || d_head_v != v->ne[0] || k->ne[1] != v->ne[1] || k->ne[3] != v->ne[3]) {
+        return false;
+    }
+    if (q->ne[3] != k->ne[3]) {
+        return false;
+    }
+    if (n_head_kv <= 0 || n_head % n_head_kv != 0 || k->ne[2] != v->ne[2]) {
+        return false;
+    }
+    if (dst->ne[0] != d_head_v || dst->ne[1] != n_head || dst->ne[2] != n_q || dst->ne[3] != n_batch) {
+        return false;
+    }
+    if ((d_head_q % 8) != 0 || (d_head_v % 4) != 0) {
+        return false;
+    }
+
+    float params[3];
+    memcpy(params, dst->op_params, sizeof(params));
+    if (params[1] != 0.0f || params[2] != 0.0f) {
+        return false;
+    }
+
+    const int heads_total = n_head * n_batch;
+    const int qpack = d_head_q / 4;
+    const int vpack = d_head_v / 4;
+    const int npack = ggml_cl_round_up_div(n_kv, 4);
+
+    if ((size_t) n_q > backend_ctx->image2d_max_width || (size_t) n_kv > backend_ctx->image2d_max_width) {
+        return false;
+    }
+    if ((size_t) heads_total * (size_t) qpack > backend_ctx->image2d_max_height ||
+        (size_t) heads_total * (size_t) vpack > backend_ctx->image2d_max_height) {
+        return false;
+    }
+    if ((size_t) npack * (size_t) heads_total * (size_t) d_head_q > backend_ctx->image_max_buffer_size ||
+        (size_t) npack * (size_t) heads_total * (size_t) n_q > backend_ctx->image_max_buffer_size) {
+        return false;
+    }
+
+    return true;
+}
+
+static void ggml_cl_adreno_xmem_attn_run(
+        ggml_backend_t backend,
+        const ggml_tensor * q,
+        const ggml_tensor * k,
+        ggml_tensor * dst) {
+    ggml_backend_opencl_context * backend_ctx = (ggml_backend_opencl_context *) backend->context;
+    auto & xstate = backend_ctx->adreno_xmem_attn;
+    auto & s = xstate.scratch;
+    static bool logged = false;
+    if (!logged) {
+        GGML_LOG_INFO("ggml_opencl: using Adreno xmem attention path\n");
+        logged = true;
+    }
+
+    const ggml_tensor * v = dst->src[2];
+
+    ggml_tensor_extra_cl * extra_q = (ggml_tensor_extra_cl *) q->extra;
+    ggml_tensor_extra_cl * extra_k = (ggml_tensor_extra_cl *) k->extra;
+    ggml_tensor_extra_cl * extra_v = (ggml_tensor_extra_cl *) v->extra;
+    ggml_tensor_extra_cl * extra_o = (ggml_tensor_extra_cl *) dst->extra;
+
+    const cl_ulong offset_q = extra_q->offset + q->view_offs;
+    const cl_ulong offset_k = extra_k->offset + k->view_offs;
+    const cl_ulong offset_v = extra_v->offset + v->view_offs;
+    const cl_ulong offset_o = extra_o->offset + dst->view_offs;
+
+    const int n_q = q->ne[1];
+    const int n_kv = k->ne[1];
+    const int d_head_q = q->ne[0];
+    const int d_head_v = v->ne[0];
+    const int n_head = q->ne[2];
+    const int n_head_kv = k->ne[2];
+    const int n_batch = q->ne[3];
+    const int heads_total = n_head * n_batch;
+    const int qpack = d_head_q / 4;
+    const int opack = d_head_v / 4;
+    const int npack = ggml_cl_round_up_div(n_kv, 4);
+    const float scale = ((const float *) dst->op_params)[0];
+
+    GGML_ASSERT(ggml_cl_adreno_xmem_attn_prepare(backend_ctx, n_q, n_kv, d_head_q, d_head_v, heads_total));
+    const ggml_cl_adreno_xmem_attn_schedule sched =
+        ggml_cl_adreno_xmem_attn_select_schedule(backend_ctx, n_q, n_kv, heads_total);
+
+    {
+        size_t gws[3] = {(size_t) n_q, (size_t) heads_total, (size_t) qpack};
+        size_t lws[3] = {8, 1, (size_t) ((qpack <= 32) ? qpack : 1)};
+        cl_kernel kernel = xstate.kernel_q_f32_to_img_scaled;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra_q->data_device));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_ulong), &offset_q));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &s.q_img));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(float),    &scale));
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int),      &d_head_q));
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int),      &n_q));
+        CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int),      &n_head));
+        CL_CHECK(clSetKernelArg(kernel, 7, sizeof(int),      &n_batch));
+        CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_ulong), &q->nb[1]));
+        CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_ulong), &q->nb[2]));
+        CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong), &q->nb[3]));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        size_t gws[3] = {(size_t) n_kv, (size_t) heads_total, (size_t) qpack};
+        size_t lws[3] = {8, 1, (size_t) ((qpack <= 32) ? qpack : 1)};
+        cl_kernel kernel = xstate.kernel_kv_f16_to_img_gqa;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra_k->data_device));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_ulong), &offset_k));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &s.k_img));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int),      &d_head_q));
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int),      &n_kv));
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int),      &n_head));
+        CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int),      &n_head_kv));
+        CL_CHECK(clSetKernelArg(kernel, 7, sizeof(int),      &n_batch));
+        CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_ulong), &k->nb[1]));
+        CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_ulong), &k->nb[2]));
+        CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong), &k->nb[3]));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        size_t gws[3] = {(size_t) n_kv, (size_t) heads_total, (size_t) opack};
+        size_t lws[3] = {8, 1, (size_t) ((opack <= 32) ? opack : 1)};
+        cl_kernel kernel = xstate.kernel_kv_f16_to_img_gqa;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra_v->data_device));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_ulong), &offset_v));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &s.v_img));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int),      &d_head_v));
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int),      &n_kv));
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int),      &n_head));
+        CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int),      &n_head_kv));
+        CL_CHECK(clSetKernelArg(kernel, 7, sizeof(int),      &n_batch));
+        CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_ulong), &v->nb[1]));
+        CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_ulong), &v->nb[2]));
+        CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong), &v->nb[3]));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        size_t gws[3] = {(size_t) d_head_q, (size_t) heads_total, (size_t) npack};
+        size_t lws[3] = {(size_t) MIN(64, d_head_q), (size_t) (heads_total >= 2 ? 2 : 1), (size_t) MIN(8, npack > 0 ? npack : 1)};
+        if (lws[0] * lws[1] * lws[2] > backend_ctx->max_workgroup_size) {
+            lws[1] = 1;
+        }
+        cl_kernel kernel = xstate.kernel_k_gather;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.k_transpose_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.k_img));
+        ggml_cl_set_arg_int4(kernel, 2, n_kv, heads_total, npack, d_head_q);
+        ggml_cl_set_arg_int4(kernel, 3, qpack, 0, 0, 0);
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+    ggml_cl_adreno_xmem_attn_barrier(backend_ctx);
+
+    {
+        const size_t groups16 = (size_t) ggml_cl_round_up_div(heads_total * d_head_q, 16);
+        const size_t packed_linear = (size_t) n_kv * groups16;
+        const size_t lws0 = MIN((size_t) 1024, backend_ctx->max_workgroup_size);
+        size_t gws[3] = {ggml_cl_round_up(packed_linear, lws0), 1, 1};
+        size_t lws[3] = {lws0, 1, 1};
+        ggml_fp16_t tail_mask[4];
+        ggml_cl_adreno_xmem_attn_make_tail_mask(n_kv, tail_mask);
+
+        cl_kernel kernel = xstate.kernel_pack_k;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.k_packed_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.k_transpose_img1d));
+        ggml_cl_set_arg_int4(kernel, 2, 8, (int) packed_linear, qpack, d_head_q);
+        ggml_cl_set_arg_int4(kernel, 3, heads_total, heads_total, heads_total, npack);
+        ggml_cl_set_arg_int4(kernel, 4, d_head_q, 0, 0, 0);
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(tail_mask), tail_mask));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        size_t lws[3] = {(size_t) sched.qk_lws0, 1, (size_t) sched.qk_lws2};
+        const int slices_per_group = sched.qk_lws2 * 8;
+        const size_t groups_z = (size_t) ggml_cl_round_up_div(npack, slices_per_group);
+        const size_t groups_x = (size_t) ggml_cl_round_up_div(n_q, sched.qk_lws0);
+        size_t gws[3] = {
+            lws[0] * groups_z,
+            groups_x,
+            (size_t) heads_total * lws[2],
+        };
+
+        cl_kernel kernel = xstate.kernel_qk_gemm;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.score_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.k_packed_buf));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &s.xmem_qk));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &s.q_img));
+        ggml_cl_set_arg_int4(kernel, 4, heads_total, npack, n_q, 32);
+        ggml_cl_set_arg_int4(kernel, 5, qpack, 0, 0, heads_total);
+        ggml_cl_set_arg_int4(kernel, 6, qpack, 1, 1, 0);
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+    ggml_cl_adreno_xmem_attn_barrier(backend_ctx);
+
+    {
+        size_t lws[3] = {(size_t) sched.softmax_reduce_lws0, 1, 1};
+        size_t gws[3] = {ggml_cl_round_up((size_t) n_q, lws[0]), (size_t) heads_total, 1};
+        cl_kernel kernel = xstate.kernel_softmax_reduce_basic;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.score_img1d));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.softmax_stats_img2d));
+        ggml_cl_set_arg_int4(kernel, 2, heads_total, 1, n_q, n_kv);
+        ggml_cl_set_arg_int4(kernel, 3, heads_total, n_q, 0, 0);
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+    {
+        size_t lws[3] = {(size_t) sched.softmax_apply_lws0, 1, (size_t) sched.softmax_apply_lws2};
+        size_t gws[3] = {
+            ggml_cl_round_up((size_t) n_q, lws[0]),
+            (size_t) heads_total,
+            ggml_cl_round_up((size_t) npack, lws[2]),
+        };
+        cl_kernel kernel = xstate.kernel_softmax_apply_basic;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.prob_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.score_img1d));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &s.softmax_stats_img2d));
+        ggml_cl_set_arg_int4(kernel, 3, heads_total, npack, n_q, 1);
+        ggml_cl_set_arg_int4(kernel, 4, heads_total, n_q, 0, 0);
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+    ggml_cl_adreno_xmem_attn_barrier(backend_ctx);
+
+    {
+        const size_t groups16 = (size_t) ggml_cl_round_up_div(heads_total * d_head_v, 16);
+        const size_t packed_linear = (size_t) n_kv * groups16;
+        const size_t lws0 = MIN((size_t) 1024, backend_ctx->max_workgroup_size);
+        size_t gws[3] = {ggml_cl_round_up(packed_linear, lws0), 1, 1};
+        size_t lws[3] = {lws0, 1, 1};
+        ggml_fp16_t tail_mask[4];
+        ggml_cl_adreno_xmem_attn_make_tail_mask(n_kv, tail_mask);
+
+        cl_kernel kernel = xstate.kernel_pack_v;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.v_packed_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.v_img));
+        ggml_cl_set_arg_int4(kernel, 2, 8, (int) packed_linear, npack, n_kv);
+        ggml_cl_set_arg_int4(kernel, 3, heads_total, heads_total, opack, 0);
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(tail_mask), tail_mask));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        size_t lws[3] = {(size_t) sched.pv_lws0, 1, (size_t) sched.pv_lws2};
+        const int blocks = ggml_cl_round_up_div(opack, 8);
+        const size_t groups_z = (size_t) ggml_cl_round_up_div(blocks, sched.pv_lws2);
+        const size_t groups_x = (size_t) ggml_cl_round_up_div(n_q, sched.pv_lws0);
+        size_t gws[3] = {
+            lws[0] * groups_z,
+            groups_x,
+            (size_t) heads_total * lws[2],
+        };
+
+        cl_kernel kernel = xstate.kernel_pv_gemm;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.v_packed_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.xmem_pv));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &s.prob_img1d));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &s.out_img));
+        ggml_cl_set_arg_int4(kernel, 4, heads_total, opack, n_q, 32);
+        ggml_cl_set_arg_int4(kernel, 5, npack, 0, 0, heads_total);
+        ggml_cl_set_arg_int4(kernel, 6, heads_total * n_q, npack, n_q, 1);
+        ggml_cl_set_arg_int4(kernel, 7, 1, 0, 0, 0);
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        size_t gws[3] = {(size_t) n_q, (size_t) heads_total, (size_t) opack};
+        size_t lws[3] = {8, 1, (size_t) ((opack <= 32) ? opack : 1)};
+        cl_kernel kernel = xstate.kernel_img_to_f32;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra_o->data_device));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_ulong), &offset_o));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &s.out_img));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int),      &d_head_v));
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int),      &n_q));
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int),      &n_head));
+        CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int),      &n_batch));
+        CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_ulong), &dst->nb[1]));
+        CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_ulong), &dst->nb[2]));
+        CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_ulong), &dst->nb[3]));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+}
+
+#endif // GGML_OPENCL_USE_ADRENO_KERNELS
+
 static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, const ggml_tensor * k, ggml_tensor * dst) {
     const ggml_tensor * v = dst->src[2];
     const ggml_tensor * mask = dst->src[3];
@@ -13710,6 +14337,13 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     const int n_head = q->ne[2];
     const int n_head_kv = k->ne[2];
     const int n_batch = q->ne[3];
+
+#ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+    if (ggml_cl_adreno_xmem_attn_can_use(backend_ctx, q, k, dst)) {
+        ggml_cl_adreno_xmem_attn_run(backend, q, k, dst);
+        return;
+    }
+#endif
 
     // DK=512 (Gemma-4 global layers) runs decode-only (q1 / q1_split) on
     // Adreno - it never uses the BM-tile path, and the prepass + split-tile

--- a/src/ggml-opencl/kernels/gemm_noshuffle_q4_0_f32.cl
+++ b/src/ggml-opencl/kernels/gemm_noshuffle_q4_0_f32.cl
@@ -35,23 +35,39 @@ kernel void kernel_gemm_noshuffle_q4_0_f32(
     int gx = get_global_id(1);
     int gx_2 = gx << 2;
 
-    half8 c0 = 0, c1 = 0, c2 = 0, c3 = 0; // 8x4 output elements
-    half8 B; // registers for activations
-    half4 dequantized_weights; // registers for dequantized weights
+#ifdef USE_F32_ACT
+#define ACC_TYPE float8
+#define ACT_TYPE float8
+#define WEIGHT_TYPE float4
+#define SCALE_TYPE float4
+#define LOAD_ACT4(img, idx) read_imagef((img), (idx))
+#define LOAD_SCALE4(ptr) convert_float4(vload4(0, (ptr)))
+#else
+#define ACC_TYPE half8
+#define ACT_TYPE half8
+#define WEIGHT_TYPE half4
+#define SCALE_TYPE half4
+#define LOAD_ACT4(img, idx) read_imageh((img), (idx))
+#define LOAD_SCALE4(ptr) vload4(0, (ptr))
+#endif
+
+    ACC_TYPE c0 = 0, c1 = 0, c2 = 0, c3 = 0; // 8x4 output elements
+    ACT_TYPE B; // registers for activations
+    WEIGHT_TYPE dequantized_weights; // registers for dequantized weights
     __global const ushort* weight_ptr = src0_q + gx_2; // pointer for weights
     __global const half* scale_ptr = src0_d + gx_2; // pointer for scales
 
     for(int i=0; i<k; i+=4){ //loop through K dimension
 
-        B.s0123 = read_imageh(src1, gy*2 + (i)*(n_4));
-        B.s4567 = read_imageh(src1, gy*2 + (i)*(n_4)+1);
+        B.s0123 = LOAD_ACT4(src1, gy*2 + (i)*(n_4));
+        B.s4567 = LOAD_ACT4(src1, gy*2 + (i)*(n_4)+1);
 
         // keep (i/4) and (i/32) in parenthesis, rounds down
         // load 4 consecutive groups of 4 weights
         ushort4 bits4 = vload4(0, weight_ptr + (i/4)*(m)); // (i/4) because weights grouped in 4s
 
         // load 4 consecutive scales
-        half4 scale = vload4(0, scale_ptr + (i/32)*(m));// (i/32) because 1 scale per 32 elements
+        SCALE_TYPE scale = LOAD_SCALE4(scale_ptr + (i/32)*(m));// (i/32) because 1 scale per 32 elements
 
         // j=0
         dequantized_weights.s0 = ((bits4.s0 & (0x000F)) - 8) * scale.s0; // dequantize a row of the 16 weights
@@ -64,8 +80,8 @@ kernel void kernel_gemm_noshuffle_q4_0_f32(
         c3 += B * dequantized_weights.s3;
 
         // j=1
-        B.s0123 = read_imageh(src1, gy*2 + (i+1)*(n_4));
-        B.s4567 = read_imageh(src1, gy*2 + (i+1)*(n_4)+1);
+        B.s0123 = LOAD_ACT4(src1, gy*2 + (i+1)*(n_4));
+        B.s4567 = LOAD_ACT4(src1, gy*2 + (i+1)*(n_4)+1);
         dequantized_weights.s0 = (((bits4.s0 & (0x00F0)) >> 4) - 8) * scale.s0; // dequantize a row of the 16 weights
         dequantized_weights.s1 = (((bits4.s1 & (0x00F0)) >> 4) - 8) * scale.s1;
         dequantized_weights.s2 = (((bits4.s2 & (0x00F0)) >> 4) - 8) * scale.s2;
@@ -76,8 +92,8 @@ kernel void kernel_gemm_noshuffle_q4_0_f32(
         c3 += B * dequantized_weights.s3;
 
         // j=2
-        B.s0123 = read_imageh(src1, gy*2 + (i+2)*(n_4));
-        B.s4567 = read_imageh(src1, gy*2 + (i+2)*(n_4)+1);
+        B.s0123 = LOAD_ACT4(src1, gy*2 + (i+2)*(n_4));
+        B.s4567 = LOAD_ACT4(src1, gy*2 + (i+2)*(n_4)+1);
         dequantized_weights.s0 = (((bits4.s0 & (0x0F00)) >> 8) - 8) * scale.s0; // dequantize a row of the 16 weights
         dequantized_weights.s1 = (((bits4.s1 & (0x0F00)) >> 8) - 8) * scale.s1;
         dequantized_weights.s2 = (((bits4.s2 & (0x0F00)) >> 8) - 8) * scale.s2;
@@ -88,8 +104,8 @@ kernel void kernel_gemm_noshuffle_q4_0_f32(
         c3 += B * dequantized_weights.s3;
 
         // j=3
-        B.s0123 = read_imageh(src1, gy*2 + (i+3)*(n_4));
-        B.s4567 = read_imageh(src1, gy*2 + (i+3)*(n_4)+1);
+        B.s0123 = LOAD_ACT4(src1, gy*2 + (i+3)*(n_4));
+        B.s4567 = LOAD_ACT4(src1, gy*2 + (i+3)*(n_4)+1);
         dequantized_weights.s0 = (((bits4.s0 & (0xF000)) >> 12) - 8) * scale.s0; // dequantize a row of the 16 weights
         dequantized_weights.s1 = (((bits4.s1 & (0xF000)) >> 12) - 8) * scale.s1;
         dequantized_weights.s2 = (((bits4.s2 & (0xF000)) >> 12) - 8) * scale.s2;
@@ -136,4 +152,11 @@ kernel void kernel_gemm_noshuffle_q4_0_f32(
     if(idx+3 < m*n_no_padding){
         vstore4((float4)(c0.s7, c1.s7, c2.s7, c3.s7), 0, dst + idx);
     }
+
+#undef ACC_TYPE
+#undef ACT_TYPE
+#undef WEIGHT_TYPE
+#undef SCALE_TYPE
+#undef LOAD_ACT4
+#undef LOAD_SCALE4
 }

--- a/src/ggml-opencl/kernels/get_rows.cl
+++ b/src/ggml-opencl/kernels/get_rows.cl
@@ -18,6 +18,13 @@ struct block_q4_0
     uint8_t qs[QK4_0 / 2];
 };
 
+enum {
+    Q4_0_LAYOUT_AOS = 0,
+    Q4_0_LAYOUT_SOA = 1,
+    Q4_0_LAYOUT_ADRENO_TRANSPOSED = 2,
+    Q4_0_LAYOUT_ADRENO_MOE_TRANS4 = 3,
+};
+
 
 //------------------------------------------------------------------------------
 // dequantize_q4_0_f32, dequantize_q4_0_f16
@@ -164,13 +171,16 @@ kernel void kernel_get_rows_q4_0(
         ulong nb12,
         ulong nb1,
         ulong nb2,
-        ulong nb3
+        ulong nb3,
+        global void * src0_d,
+        int q4_0_layout,
+        int ne01
 ) {
     src0 = (global void*)((global char*)src0 + offset0);
     src1 = (global int*)((global char*)src1 + offset1);
     dst = (global float*)((global char*)dst + offsetd);
 
-    const int NL = 2;
+    const int block_size = sizeof(struct block_q4_0);
 
     int i10 = get_group_id(0);
     int i11 = get_group_id(1);
@@ -180,14 +190,67 @@ kernel void kernel_get_rows_q4_0(
 
     int i02 = i11;
     int i03 = i12;
+    const int nb = ne00 / QK4_0;
+    const ulong row_byte_offset = (ulong)r*nb01 + (ulong)i02*nb02 + (ulong)i03*nb03;
+    const ulong row_block_offset = row_byte_offset / block_size;
 
     for (int ind = get_local_id(0); ind < ne00/16; ind += get_local_size(0)) {
-        float16 temp;
-        if (ind >= ne00) {
-            return;
+        const int ib = ind / 2;
+        const int ih = ind & 1;
+        half d;
+        global float * dst_row = (global float *) ((global char *) dst + (ulong)i12*nb3 + (ulong)i11*nb2 + (ulong)i10*nb1);
+        const int dst_base = ind * 16;
+
+        if (q4_0_layout == Q4_0_LAYOUT_ADRENO_TRANSPOSED) {
+            global uchar * q = (global uchar *) src0;
+            global half * scales = (global half *) src0_d;
+            d = scales[ib * ne01 + r];
+            const float fd = (float)d;
+            for (int j = 0; j < 8; ++j) {
+                const int byte_idx = ih * 8 + j;
+                const int col = ib * 8 + byte_idx / 2;
+                const ulong q_offset = 2 * ((ulong)col * ne01 + r) + (byte_idx & 1);
+                const uint packed = q[q_offset];
+                dst_row[dst_base + 2*j + 0] = ((float)(packed & 0x0F) - 8.0f) * fd;
+                dst_row[dst_base + 2*j + 1] = ((float)(packed >> 4)   - 8.0f) * fd;
+            }
+        } else if (q4_0_layout == Q4_0_LAYOUT_ADRENO_MOE_TRANS4) {
+            global uchar * q = (global uchar *) src0;
+            global half * scales = (global half *) src0_d;
+            d = scales[(ulong)i02 * nb * ne01 + (ulong)ib * ne01 + r];
+            const float fd = (float)d;
+            for (int j = 0; j < 8; ++j) {
+                const int byte_idx = ih * 8 + j;
+                const int word_idx = byte_idx / 4;
+                const int byte_in_word = byte_idx & 3;
+                const ulong q_word_offset = ((ulong)i02 * nb * ne01 + (ulong)ib * ne01) * 4 + r + (ulong)word_idx * ne01;
+                const uint packed = q[4 * q_word_offset + byte_in_word];
+                dst_row[dst_base + 2*j + 0] = ((float)(packed & 0x0F) - 8.0f) * fd;
+                dst_row[dst_base + 2*j + 1] = ((float)(packed >> 4)   - 8.0f) * fd;
+            }
+        } else {
+            global uchar * q;
+            if (q4_0_layout == Q4_0_LAYOUT_SOA) {
+                global half * scales = (global half *) src0_d;
+                d = scales[row_block_offset + ib];
+                q = (global uchar *) src0 + (row_block_offset + ib) * (QK4_0 / 2);
+            } else {
+                global struct block_q4_0 * b = (global struct block_q4_0 *) ((global char *) src0 + row_byte_offset) + ib;
+                d = b->d;
+                q = (global uchar *) &b->qs[0];
+            }
+
+            const float fd = (float)d;
+            for (int j = 0; j < 8; ++j) {
+                uint packed;
+                if (ih == 0) {
+                    packed = (q[2*j + 0] & 0x0F) | ((q[2*j + 1] & 0x0F) << 4);
+                } else {
+                    packed = ((q[2*j + 0] & 0xF0) >> 4) | (q[2*j + 1] & 0xF0);
+                }
+                dst_row[dst_base + 2*j + 0] = ((float)(packed & 0x0F) - 8.0f) * fd;
+                dst_row[dst_base + 2*j + 1] = ((float)(packed >> 4)   - 8.0f) * fd;
+            }
         }
-        dequantize_q4_0_f32(
-            ((global struct block_q4_0 *) ((global char *) src0 + r*nb01 + i02*nb02 + i03*nb03)) + ind/NL, ind%NL, &temp);
-        *(((global float16 *) ((global char *) dst + i12*nb3 + i11*nb2 + i10*nb1)) + ind) = temp;
     }
 }

--- a/src/ggml-opencl/kernels/sdpa_xmem_f32_f16_os8.cl
+++ b/src/ggml-opencl/kernels/sdpa_xmem_f32_f16_os8.cl
@@ -1,0 +1,968 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+#pragma OPENCL EXTENSION cl_qcom_subgroup_uniform_load : enable
+#pragma OPENCL EXTENSION cl_qcom_subgroup_constant_load : enable
+
+#define bool2 uchar2
+#define bool3 uchar3
+#define bool4 uchar4
+
+__constant sampler_t smp_none = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE  | CLK_FILTER_NEAREST;
+__constant sampler_t smp_zero = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+
+inline int round_up_div(int x, int y) {
+    return (x + y - 1) / y;
+}
+
+inline half4 rotate_tail_mask(half4 in_mask) {
+    return (half4)(in_mask.y, in_mask.z, in_mask.w, in_mask.x);
+}
+
+__kernel void adreno_xmem_attn_q_f32_to_img_scaled(
+        const global void * src_void,
+        ulong src_offset,
+        write_only image2d_t dst_image2d,
+        const float scale,
+        const int d_head,
+        const int n_q,
+        const int n_head,
+        const int n_batch,
+        const ulong src_nb1,
+        const ulong src_nb2,
+        const ulong src_nb3) {
+    const int x = get_global_id(0);
+    const int flat_h = get_global_id(1);
+    const int d = get_global_id(2);
+
+    const int heads_total = n_head * n_batch;
+    const int kpack = d_head / 4;
+
+    if (x >= n_q || flat_h >= heads_total || d >= kpack) {
+        return;
+    }
+
+    const int batch = flat_h / n_head;
+    const int head  = flat_h % n_head;
+    const int c = d * 4;
+
+    const global char * src_base = (const global char *) src_void + src_offset;
+    const global float * row_ptr = (const global float *) (src_base + batch * src_nb3 + head * src_nb2 + x * src_nb1);
+
+    half4 out = (half4)(0.0h);
+    out.x = convert_half(row_ptr[c + 0] * scale);
+    if (c + 1 < d_head) out.y = convert_half(row_ptr[c + 1] * scale);
+    if (c + 2 < d_head) out.z = convert_half(row_ptr[c + 2] * scale);
+    if (c + 3 < d_head) out.w = convert_half(row_ptr[c + 3] * scale);
+
+    write_imageh(dst_image2d, (int2)(x, flat_h * kpack + d), out);
+}
+
+__kernel void adreno_xmem_attn_kv_f32_to_img_gqa(
+        const global void * src_void,
+        ulong src_offset,
+        write_only image2d_t dst_image2d,
+        const int d_head,
+        const int n_kv,
+        const int n_head,
+        const int n_head_kv,
+        const int n_batch,
+        const ulong src_nb1,
+        const ulong src_nb2,
+        const ulong src_nb3) {
+    const int x = get_global_id(0);
+    const int flat_h = get_global_id(1);
+    const int d = get_global_id(2);
+
+    const int heads_total = n_head * n_batch;
+    const int kpack = d_head / 4;
+
+    if (x >= n_kv || flat_h >= heads_total || d >= kpack) {
+        return;
+    }
+
+    const int batch = flat_h / n_head;
+    const int head  = flat_h % n_head;
+    const int head_kv = head / (n_head / n_head_kv);
+    const int c = d * 4;
+
+    const global char * src_base = (const global char *) src_void + src_offset;
+    const global float * row_ptr = (const global float *) (src_base + batch * src_nb3 + head_kv * src_nb2 + x * src_nb1);
+
+    half4 out = (half4)(0.0h);
+    out.x = convert_half(row_ptr[c + 0]);
+    if (c + 1 < d_head) out.y = convert_half(row_ptr[c + 1]);
+    if (c + 2 < d_head) out.z = convert_half(row_ptr[c + 2]);
+    if (c + 3 < d_head) out.w = convert_half(row_ptr[c + 3]);
+
+    write_imageh(dst_image2d, (int2)(x, flat_h * kpack + d), out);
+}
+
+__kernel void adreno_xmem_attn_kv_f16_to_img_gqa(
+        const global void * src_void,
+        ulong src_offset,
+        write_only image2d_t dst_image2d,
+        const int d_head,
+        const int n_kv,
+        const int n_head,
+        const int n_head_kv,
+        const int n_batch,
+        const ulong src_nb1,
+        const ulong src_nb2,
+        const ulong src_nb3) {
+    const int x = get_global_id(0);
+    const int flat_h = get_global_id(1);
+    const int d = get_global_id(2);
+
+    const int heads_total = n_head * n_batch;
+    const int kpack = d_head / 4;
+
+    if (x >= n_kv || flat_h >= heads_total || d >= kpack) {
+        return;
+    }
+
+    const int batch = flat_h / n_head;
+    const int head  = flat_h % n_head;
+    const int head_kv = head / (n_head / n_head_kv);
+    const int c = d * 4;
+
+    const global char * src_base = (const global char *) src_void + src_offset;
+    const global half * row_ptr = (const global half *) (src_base + batch * src_nb3 + head_kv * src_nb2 + x * src_nb1);
+
+    half4 out = (half4)(0.0h);
+    out.x = row_ptr[c + 0];
+    if (c + 1 < d_head) out.y = row_ptr[c + 1];
+    if (c + 2 < d_head) out.z = row_ptr[c + 2];
+    if (c + 3 < d_head) out.w = row_ptr[c + 3];
+
+    write_imageh(dst_image2d, (int2)(x, flat_h * kpack + d), out);
+}
+
+__kernel void adreno_xmem_attn_img_to_f32(
+        global void * dst_void,
+        ulong dst_offset,
+        read_only image2d_t src_image2d,
+        const int d_head,
+        const int n_q,
+        const int n_head,
+        const int n_batch,
+        const ulong dst_nb1,
+        const ulong dst_nb2,
+        const ulong dst_nb3) {
+    const int x = get_global_id(0);
+    const int flat_h = get_global_id(1);
+    const int d = get_global_id(2);
+
+    const int heads_total = n_head * n_batch;
+    const int kpack = d_head / 4;
+
+    if (x >= n_q || flat_h >= heads_total || d >= kpack) {
+        return;
+    }
+
+    const int batch = flat_h / n_head;
+    const int head  = flat_h % n_head;
+    const int c = d * 4;
+
+    global char * dst_base = (global char *) dst_void + dst_offset;
+    global float * row_ptr = (global float *) (dst_base + batch * dst_nb3 + x * dst_nb2 + head * dst_nb1);
+
+    const half4 in_value = read_imageh(src_image2d, smp_zero, (int2)(x, flat_h * kpack + d));
+    row_ptr[c + 0] = convert_float(in_value.x);
+    if (c + 1 < d_head) row_ptr[c + 1] = convert_float(in_value.y);
+    if (c + 2 < d_head) row_ptr[c + 2] = convert_float(in_value.z);
+    if (c + 3 < d_head) row_ptr[c + 3] = convert_float(in_value.w);
+}
+
+__kernel void adreno_xmem_attn_k_gather(
+        global half4 * dst_tensor_buffer,
+        read_only image2d_t src_tensor_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1) {
+  int X = get_global_id(0);
+  int Y = get_global_id(1);
+  int S = get_global_id(2);
+  if (X >= shared_int4_0.w || Y >= shared_int4_0.y || S >= shared_int4_0.z) {
+    return;
+  }
+  half temps[4];
+  temps[0] = (half)(0.f);
+  temps[1] = (half)(0.f);
+  temps[2] = (half)(0.f);
+  temps[3] = (half)(0.f);
+  for (int i = 0; i < 4; ++i) {
+    int dst_channel = S * 4 + i;
+    if (dst_channel < shared_int4_0.x) {
+      int s_y = Y;
+      int s_x = dst_channel;
+      int s_c = X;
+      {
+        int slice_coord_TMP = (s_c) / 4;
+        int sub_ch_coord_TMP = (s_c) % 4;
+        half4 src_TMP = read_imageh(src_tensor_image2d, smp_zero, (int2)((s_x), ((s_y) * shared_int4_1.x + (slice_coord_TMP))));
+        temps[i] = (half[4]){src_TMP.x, src_TMP.y, src_TMP.z, src_TMP.w}[sub_ch_coord_TMP];
+      };
+    }
+  }
+  half4 result;
+  result.x = temps[0];
+  result.y = temps[1];
+  result.z = temps[2];
+  result.w = temps[3];
+  dst_tensor_buffer[(((S) * shared_int4_0.y + (Y)) * shared_int4_0.w + (X))] = result;
+}
+
+__kernel void adreno_xmem_attn_pack_k(
+        global half4 * dst_tensor_buffer,
+        read_only image1d_buffer_t src_image_buffer,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1,
+        const int4 shared_int4_2,
+        const half4 shared_half4_0) {
+  int linear_index = get_global_id(0);
+  if (linear_index >= shared_int4_0.y) return;
+  if (get_global_id(1) != 0) return;
+  if (get_global_id(2) != 0) return;
+  int dst_o_sp_i_ogroup = linear_index;
+  int dst_ogroup = dst_o_sp_i_ogroup % shared_int4_0.x;
+  int dst_o_sp_i = dst_o_sp_i_ogroup / shared_int4_0.x;
+  int dst_i = dst_o_sp_i % shared_int4_0.z;
+  int dst_o_sp = dst_o_sp_i / shared_int4_0.z;
+  int dst_sp = dst_o_sp % shared_int4_1.x;
+  int dst_o = dst_o_sp / shared_int4_1.x;
+  int i_slice = dst_i;
+  int o_slice = dst_o * shared_int4_0.x + dst_ogroup;
+  int spatial_linear = dst_sp;
+  int W = spatial_linear % shared_int4_1.y;
+  int H = spatial_linear / shared_int4_1.y;
+  half4 w0 = (half4)(0);
+  half4 w1 = (half4)(0);
+  half4 w2 = (half4)(0);
+  half4 w3 = (half4)(0);
+
+  if (i_slice * 4 < shared_int4_0.w && o_slice < shared_int4_1.w) {
+    w0 = read_imageh(src_image_buffer, (((o_slice) * shared_int4_1.z + (W)) * shared_int4_2.x + (i_slice * 4)));
+  }
+  if (i_slice * 4 + 1 < shared_int4_0.w && o_slice < shared_int4_1.w) {
+    w1 = read_imageh(src_image_buffer, (((o_slice) * shared_int4_1.z + (W)) * shared_int4_2.x + (i_slice * 4 + 1)));
+  }
+  if (i_slice * 4 + 2 < shared_int4_0.w && o_slice < shared_int4_1.w) {
+    w2 = read_imageh(src_image_buffer, (((o_slice) * shared_int4_1.z + (W)) * shared_int4_2.x + (i_slice * 4 + 2)));
+  }
+  if (i_slice * 4 + 3 < shared_int4_0.w && o_slice < shared_int4_1.w) {
+    w3 = read_imageh(src_image_buffer, (((o_slice) * shared_int4_1.z + (W)) * shared_int4_2.x + (i_slice * 4 + 3)));
+  }
+  if (o_slice == shared_int4_1.w - 1) {
+    half4 mask = (half4)(shared_half4_0.y, shared_half4_0.z, shared_half4_0.w, shared_half4_0.x);
+    w0 *= mask;
+    w1 *= mask;
+    w2 *= mask;
+    w3 *= mask;
+  }
+  half4 r0 = w0;
+  half4 r1 = w1;
+  half4 r2 = w2;
+  half4 r3 = w3;
+  dst_tensor_buffer[linear_index * 4 + 0] = r0;
+  dst_tensor_buffer[linear_index * 4 + 1] = r1;
+  dst_tensor_buffer[linear_index * 4 + 2] = r2;
+  dst_tensor_buffer[linear_index * 4 + 3] = r3;
+}
+
+__attribute__((qcom_max_concurrent_subgroups(12)))
+__kernel void adreno_xmem_attn_qk_gemm(
+        global half4 * dst_tensor_buffer,
+        constant half8 * weights_buffer __attribute__((sub_group_uniform)),
+        constant half8 * xmem_buffer __attribute__((max_constant_size((6144)))),
+        read_only image2d_t src_tensor_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1,
+        const int4 shared_int4_2) {
+  int X = get_group_id(1) * get_local_size(0) + get_local_id(0);
+  int Y = get_group_id(2) * get_local_size(1) + get_local_id(1);
+  int Z = get_group_id(0) * get_local_size(2) + get_local_id(2);
+  if (X >= shared_int4_0.z || Y >= shared_int4_0.x) return;
+  if (Z * 8 >= shared_int4_0.y) return;
+
+  half4 r0 = (half4)(0.f);
+  half4 r1 = (half4)(0.f);
+  half4 r2 = (half4)(0.f);
+  half4 r3 = (half4)(0.f);
+  half4 r4 = (half4)(0.f);
+  half4 r5 = (half4)(0.f);
+  half4 r6 = (half4)(0.f);
+  half4 r7 = (half4)(0.f);
+  int x_coord = mad24(X, shared_int4_2.y, shared_int4_1.y);
+  int y_coord = mad24(Y, shared_int4_2.z, shared_int4_1.z);
+  int coord_x, coord_y, coord_s;
+  int f_offset = (Z * shared_int4_1.w + Y) * shared_int4_1.x * 32;
+
+  int subgroup_id = (int)((0x1F & qcom_get_physical_sub_group_id()));
+  subgroup_id = subgroup_id % 12;
+  int c_offset = mul24(subgroup_id, shared_int4_0.w);
+  __constant half16 * weights_cache = (__constant half16 *) &xmem_buffer[c_offset];
+  coord_y = Y;
+  coord_x = X;
+  coord_s = 0;
+  do {
+    half4 src0 = read_imageh(src_tensor_image2d, smp_zero, (int2)((coord_x), ((coord_y) * shared_int4_2.x + (coord_s))));
+    coord_s++;
+    half4 src1 = read_imageh(src_tensor_image2d, smp_zero, (int2)((coord_x), ((coord_y) * shared_int4_2.x + (coord_s))));
+    coord_s++;
+    qcom_sub_group_constant_load8(xmem_buffer, weights_buffer, c_offset, f_offset >> 1, 32);
+    f_offset += 64;
+    qcom_sub_group_sync(QCOM_CLK_CONST_LOAD_SYNC);
+    r0 += src0.x * weights_cache[0].s0123;
+    r0 += src0.y * weights_cache[0].s4567;
+    r0 += src0.z * weights_cache[0].s89ab;
+    r0 += src0.w * weights_cache[0].scdef;
+    r1 += src0.x * weights_cache[1].s0123;
+    r1 += src0.y * weights_cache[1].s4567;
+    r1 += src0.z * weights_cache[1].s89ab;
+    r1 += src0.w * weights_cache[1].scdef;
+    r2 += src0.x * weights_cache[2].s0123;
+    r2 += src0.y * weights_cache[2].s4567;
+    r2 += src0.z * weights_cache[2].s89ab;
+    r2 += src0.w * weights_cache[2].scdef;
+    r3 += src0.x * weights_cache[3].s0123;
+    r3 += src0.y * weights_cache[3].s4567;
+    r3 += src0.z * weights_cache[3].s89ab;
+    r3 += src0.w * weights_cache[3].scdef;
+    r4 += src0.x * weights_cache[4].s0123;
+    r4 += src0.y * weights_cache[4].s4567;
+    r4 += src0.z * weights_cache[4].s89ab;
+    r4 += src0.w * weights_cache[4].scdef;
+    r5 += src0.x * weights_cache[5].s0123;
+    r5 += src0.y * weights_cache[5].s4567;
+    r5 += src0.z * weights_cache[5].s89ab;
+    r5 += src0.w * weights_cache[5].scdef;
+    r6 += src0.x * weights_cache[6].s0123;
+    r6 += src0.y * weights_cache[6].s4567;
+    r6 += src0.z * weights_cache[6].s89ab;
+    r6 += src0.w * weights_cache[6].scdef;
+    r7 += src0.x * weights_cache[7].s0123;
+    r7 += src0.y * weights_cache[7].s4567;
+    r7 += src0.z * weights_cache[7].s89ab;
+    r7 += src0.w * weights_cache[7].scdef;
+    r0 += src1.x * weights_cache[8].s0123;
+    r0 += src1.y * weights_cache[8].s4567;
+    r0 += src1.z * weights_cache[8].s89ab;
+    r0 += src1.w * weights_cache[8].scdef;
+    r1 += src1.x * weights_cache[9].s0123;
+    r1 += src1.y * weights_cache[9].s4567;
+    r1 += src1.z * weights_cache[9].s89ab;
+    r1 += src1.w * weights_cache[9].scdef;
+    r2 += src1.x * weights_cache[10].s0123;
+    r2 += src1.y * weights_cache[10].s4567;
+    r2 += src1.z * weights_cache[10].s89ab;
+    r2 += src1.w * weights_cache[10].scdef;
+    r3 += src1.x * weights_cache[11].s0123;
+    r3 += src1.y * weights_cache[11].s4567;
+    r3 += src1.z * weights_cache[11].s89ab;
+    r3 += src1.w * weights_cache[11].scdef;
+    r4 += src1.x * weights_cache[12].s0123;
+    r4 += src1.y * weights_cache[12].s4567;
+    r4 += src1.z * weights_cache[12].s89ab;
+    r4 += src1.w * weights_cache[12].scdef;
+    r5 += src1.x * weights_cache[13].s0123;
+    r5 += src1.y * weights_cache[13].s4567;
+    r5 += src1.z * weights_cache[13].s89ab;
+    r5 += src1.w * weights_cache[13].scdef;
+    r6 += src1.x * weights_cache[14].s0123;
+    r6 += src1.y * weights_cache[14].s4567;
+    r6 += src1.z * weights_cache[14].s89ab;
+    r6 += src1.w * weights_cache[14].scdef;
+    r7 += src1.x * weights_cache[15].s0123;
+    r7 += src1.y * weights_cache[15].s4567;
+    r7 += src1.z * weights_cache[15].s89ab;
+    r7 += src1.w * weights_cache[15].scdef;
+  } while (coord_s < shared_int4_2.x);
+
+  coord_s = mul24(Z, 8);
+  coord_x = X;
+  coord_y = Y;
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r0);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r1);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r2);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r3);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r4);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r5);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r6);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r7);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+}
+
+__kernel void adreno_xmem_attn_softmax_reduce_basic(
+        read_only image1d_buffer_t src_tensor_image_buffer,
+        write_only image2d_t dst_tensor_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1) {
+  int X = get_global_id(0);
+  int Y = get_global_id(1);
+  if (X >= shared_int4_0.z || Y >= shared_int4_0.x) return;
+  float sum = 0.0f;
+  int end_channel = shared_int4_0.w;
+  int end_slice = (end_channel + 3) / 4;
+  int start_channel = 0;
+  int start_slice = start_channel / 4;
+  bool need_per_channels_check = start_channel % 4 != 0 || end_channel % 4 != 0;
+  float maximum;
+  {
+    int slice_coord_TMP = (start_channel) / 4;
+    int sub_ch_coord_TMP = (start_channel) % 4;
+    float4 src_TMP = convert_float4(read_imageh(src_tensor_image_buffer, ((slice_coord_TMP) * shared_int4_1.x + (Y)) * shared_int4_1.y + (X)));
+    maximum = (float[4]){src_TMP.x, src_TMP.y, src_TMP.z, src_TMP.w}[sub_ch_coord_TMP];
+  };
+  for (int d = start_slice; d < end_slice; d += 1) {
+    float4 mask_dot = (float4)(1.f);
+    float4 src = convert_float4(read_imageh(src_tensor_image_buffer, ((d) * shared_int4_1.x + (Y)) * shared_int4_1.y + (X)));
+    if (need_per_channels_check && (d == start_slice || d == end_slice - 1)) {
+      if (d * 4 + 0 < start_channel || d * 4 + 0 >= end_channel) { mask_dot.x = 0.f; src.x = maximum; }
+      if (d * 4 + 1 < start_channel || d * 4 + 1 >= end_channel) { mask_dot.y = 0.f; src.y = maximum; }
+      if (d * 4 + 2 < start_channel || d * 4 + 2 >= end_channel) { mask_dot.z = 0.f; src.z = maximum; }
+      if (d * 4 + 3 < start_channel || d * 4 + 3 >= end_channel) { mask_dot.w = 0.f; src.w = maximum; }
+    }
+    float new_max = max(src.x, src.y);
+    new_max = max(new_max, src.z);
+    new_max = max(new_max, src.w);
+    new_max = max(new_max, maximum);
+    float scale = native_exp(maximum - new_max);
+    maximum = new_max;
+    sum *= scale;
+    float4 exp_res = native_exp(src - maximum);
+    sum += dot(mask_dot, exp_res);
+  }
+  float inv_sum = 1.0f / sum;
+  half4 result;
+  result.x = convert_half(inv_sum);
+  result.y = convert_half(maximum);
+  write_imageh(dst_tensor_image2d, (int2)((X), ((Y) * shared_int4_0.y + (0))), result);
+}
+
+__kernel void adreno_xmem_attn_softmax_apply_basic(
+        global half4 * dst_tensor_buffer,
+        read_only image1d_buffer_t src_tensor_image_buffer,
+        read_only image2d_t src_tensor_1_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1) {
+  int X = get_global_id(0);
+  int Y = get_global_id(1);
+  int Z = get_global_id(2);
+  if (X >= shared_int4_0.z || Y >= shared_int4_0.x || Z >= shared_int4_0.y) return;
+  half4 src = read_imageh(src_tensor_image_buffer, ((Z) * shared_int4_1.x + (Y)) * shared_int4_1.y + (X));
+  {
+    half4 src_final;
+    {
+      {
+        half4 exp_val = read_imageh(src_tensor_1_image2d, smp_zero, (int2)(((X)), (((Y)) * shared_int4_0.w + (0))));
+        src_final = exp(src - exp_val.y) * exp_val.x;
+      }
+    }
+    dst_tensor_buffer[(((Z) * shared_int4_0.x + (Y)) * shared_int4_0.z + (X))] = src_final;
+  };
+}
+
+__kernel void adreno_xmem_attn_mask_scores(
+        global half4 * dst_score_tensor_buffer,
+        read_only image1d_buffer_t src_score_image_buffer,
+        global const half * mask,
+        const int n_q,
+        const int n_kv,
+        const int heads_total,
+        const int n_head,
+        const int is_causal,
+        const ulong mask_nb1,
+        const ulong mask_nb2,
+        const ulong mask_nb3,
+        const int mask_ne2,
+        const int mask_ne3) {
+    const int X = get_global_id(0);
+    const int Y = get_global_id(1);
+    const int Z = get_global_id(2);
+    const int npack = round_up_div(n_kv, 4);
+    if (X >= n_q || Y >= heads_total || Z >= npack) {
+        return;
+    }
+
+    const int head = Y % n_head;
+    const int batch = Y / n_head;
+    const int mask_head_idx = mask ? (head % mask_ne2) : 0;
+    const int mask_batch_idx = mask ? (batch % mask_ne3) : 0;
+    const global half * mask_row = mask ? (const global half *) ((const global char *) mask + mask_batch_idx * mask_nb3 + mask_head_idx * mask_nb2 + X * mask_nb1) : 0;
+
+    const half4 score = read_imageh(src_score_image_buffer, ((Z * heads_total + Y) * n_q + X));
+    float vals[4] = {
+        convert_float(score.x),
+        convert_float(score.y),
+        convert_float(score.z),
+        convert_float(score.w),
+    };
+
+    for (int lane = 0; lane < 4; ++lane) {
+        const int k_idx = Z * 4 + lane;
+        if (k_idx >= n_kv || (is_causal && k_idx > (n_kv - n_q + X))) {
+            vals[lane] = -INFINITY;
+        } else if (mask) {
+            vals[lane] += convert_float(mask_row[k_idx]);
+        }
+    }
+
+    dst_score_tensor_buffer[((Z * heads_total + Y) * n_q + X)] = (half4)(
+            convert_half(vals[0]),
+            convert_half(vals[1]),
+            convert_half(vals[2]),
+            convert_half(vals[3]));
+}
+
+__kernel void adreno_xmem_attn_mask_all_zero(
+        global int * dst_flag,
+        global const half * mask,
+        const ulong mask_offset,
+        const int mask_elems) {
+    const int lid = get_local_id(0);
+    const int lsize = get_local_size(0);
+    const global half * mask_ptr = (const global half *) ((const global char *) mask + mask_offset);
+
+    int found = 0;
+    for (int i = lid; i < mask_elems; i += lsize) {
+        found |= mask_ptr[i] != (half) 0.0h;
+    }
+
+    __local int reduced[256];
+    reduced[lid] = found;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int stride = lsize >> 1; stride > 0; stride >>= 1) {
+        if (lid < stride) {
+            reduced[lid] |= reduced[lid + stride];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        dst_flag[0] = reduced[0];
+    }
+}
+
+__kernel void adreno_xmem_attn_softmax_reduce_masked(
+        read_only image1d_buffer_t src_tensor_image_buffer,
+        write_only image2d_t dst_tensor_image2d,
+        global const half * mask,
+        const ulong mask_offset,
+        const int has_mask,
+        const int n_q,
+        const int n_kv,
+        const int heads_total,
+        const int n_head,
+        const int is_causal,
+        const ulong mask_nb1,
+        const ulong mask_nb2,
+        const ulong mask_nb3,
+        const int mask_ne2,
+        const int mask_ne3) {
+    const int X = get_global_id(0);
+    const int Y = get_global_id(1);
+    if (X >= n_q || Y >= heads_total) {
+        return;
+    }
+
+    const int head = Y % n_head;
+    const int batch = Y / n_head;
+    const global char * mask_base = has_mask ? ((const global char *) mask + mask_offset) : 0;
+    const int mask_head_idx = has_mask ? (head % mask_ne2) : 0;
+    const int mask_batch_idx = has_mask ? (batch % mask_ne3) : 0;
+    const global half * mask_row = has_mask ? (const global half *) (mask_base + mask_batch_idx * mask_nb3 + mask_head_idx * mask_nb2 + X * mask_nb1) : 0;
+
+    float maximum = -INFINITY;
+    const int npack = round_up_div(n_kv, 4);
+    for (int d = 0; d < npack; ++d) {
+        const half4 packed_scores = read_imageh(src_tensor_image_buffer, ((d * heads_total + Y) * n_q + X));
+        float4 scores = convert_float4(packed_scores);
+        for (int lane = 0; lane < 4; ++lane) {
+            const int k_idx = d * 4 + lane;
+            float score = lane == 0 ? scores.x : lane == 1 ? scores.y : lane == 2 ? scores.z : scores.w;
+            if (k_idx >= n_kv || (is_causal && k_idx > (n_kv - n_q + X))) {
+                score = -INFINITY;
+            } else if (has_mask) {
+                score += convert_float(mask_row[k_idx]);
+            }
+            maximum = fmax(maximum, score);
+        }
+    }
+
+    float sum = 0.0f;
+    if (!isfinite(maximum)) {
+        write_imageh(dst_tensor_image2d, (int2)(X, Y), (half4)((half)0.0h, (half)0.0h, (half)0.0h, (half)0.0h));
+        return;
+    }
+
+    for (int d = 0; d < npack; ++d) {
+        const half4 packed_scores = read_imageh(src_tensor_image_buffer, ((d * heads_total + Y) * n_q + X));
+        float4 scores = convert_float4(packed_scores);
+        for (int lane = 0; lane < 4; ++lane) {
+            const int k_idx = d * 4 + lane;
+            float score = lane == 0 ? scores.x : lane == 1 ? scores.y : lane == 2 ? scores.z : scores.w;
+            if (k_idx >= n_kv || (is_causal && k_idx > (n_kv - n_q + X))) {
+                continue;
+            }
+            if (has_mask) {
+                score += convert_float(mask_row[k_idx]);
+            }
+            sum += native_exp(score - maximum);
+        }
+    }
+
+    const float inv_sum = sum > 0.0f ? 1.0f / sum : 0.0f;
+    write_imageh(dst_tensor_image2d, (int2)(X, Y), (half4)(convert_half(inv_sum), convert_half(maximum), (half)0.0h, (half)0.0h));
+}
+
+__kernel void adreno_xmem_attn_softmax_apply_masked(
+        global half4 * dst_tensor_buffer,
+        read_only image1d_buffer_t src_tensor_image_buffer,
+        read_only image2d_t src_stats_image2d,
+        global const half * mask,
+        const ulong mask_offset,
+        const int has_mask,
+        const int n_q,
+        const int n_kv,
+        const int heads_total,
+        const int n_head,
+        const int is_causal,
+        const ulong mask_nb1,
+        const ulong mask_nb2,
+        const ulong mask_nb3,
+        const int mask_ne2,
+        const int mask_ne3) {
+    const int X = get_global_id(0);
+    const int Y = get_global_id(1);
+    const int Z = get_global_id(2);
+    const int npack = round_up_div(n_kv, 4);
+    if (X >= n_q || Y >= heads_total || Z >= npack) {
+        return;
+    }
+
+    const int head = Y % n_head;
+    const int batch = Y / n_head;
+    const global char * mask_base = has_mask ? ((const global char *) mask + mask_offset) : 0;
+    const int mask_head_idx = has_mask ? (head % mask_ne2) : 0;
+    const int mask_batch_idx = has_mask ? (batch % mask_ne3) : 0;
+    const global half * mask_row = has_mask ? (const global half *) (mask_base + mask_batch_idx * mask_nb3 + mask_head_idx * mask_nb2 + X * mask_nb1) : 0;
+
+    const half4 src = read_imageh(src_tensor_image_buffer, ((Z * heads_total + Y) * n_q + X));
+    const half4 stats = read_imageh(src_stats_image2d, smp_zero, (int2)(X, Y));
+
+    half4 out = (half4)(0.0h);
+    const float inv_sum = convert_float(stats.x);
+    const float maximum = convert_float(stats.y);
+    if (inv_sum > 0.0f) {
+        const float src_vals[4] = {
+            convert_float(src.x), convert_float(src.y), convert_float(src.z), convert_float(src.w)
+        };
+        float out_vals[4] = {0, 0, 0, 0};
+        for (int lane = 0; lane < 4; ++lane) {
+            const int k_idx = Z * 4 + lane;
+            if (k_idx >= n_kv || (is_causal && k_idx > (n_kv - n_q + X))) {
+                out_vals[lane] = 0.0f;
+                continue;
+            }
+            float score = src_vals[lane];
+            if (has_mask) {
+                score += convert_float(mask_row[k_idx]);
+            }
+            out_vals[lane] = native_exp(score - maximum) * inv_sum;
+        }
+        out = (half4)(convert_half(out_vals[0]), convert_half(out_vals[1]), convert_half(out_vals[2]), convert_half(out_vals[3]));
+    }
+
+    dst_tensor_buffer[((Z * heads_total + Y) * n_q + X)] = out;
+}
+
+__kernel void adreno_xmem_attn_pack_v(
+        global half4 * dst_tensor_buffer,
+        read_only image2d_t src_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1,
+        const half4 shared_half4_0) {
+  int linear_index = get_global_id(0);
+  if (linear_index >= shared_int4_0.y) return;
+  if (get_global_id(1) != 0) return;
+  if (get_global_id(2) != 0) return;
+  int dst_o_sp_i_ogroup = linear_index;
+  int dst_ogroup = dst_o_sp_i_ogroup % shared_int4_0.x;
+  int dst_o_sp_i = dst_o_sp_i_ogroup / shared_int4_0.x;
+  int dst_i = dst_o_sp_i % shared_int4_0.z;
+  int dst_o_sp = dst_o_sp_i / shared_int4_0.z;
+  int dst_sp = dst_o_sp % shared_int4_1.x;
+  int dst_o = dst_o_sp / shared_int4_1.x;
+  int i_slice = dst_i;
+  int o_slice = dst_o * shared_int4_0.x + dst_ogroup;
+  int spatial_linear = dst_sp;
+  int W = spatial_linear % shared_int4_1.y;
+  int H = spatial_linear / shared_int4_1.y;
+  half4 w0 = (half4)(0);
+  half4 w1 = (half4)(0);
+  half4 w2 = (half4)(0);
+  half4 w3 = (half4)(0);
+
+  if (i_slice * 4 < shared_int4_0.w && o_slice < shared_int4_1.z) {
+    w0 = read_imageh(src_image2d, smp_zero, (int2)((i_slice * 4), ((W) * shared_int4_1.z + (o_slice))));
+  }
+  if (i_slice * 4 + 1 < shared_int4_0.w && o_slice < shared_int4_1.z) {
+    w1 = read_imageh(src_image2d, smp_zero, (int2)((i_slice * 4 + 1), ((W) * shared_int4_1.z + (o_slice))));
+  }
+  if (i_slice * 4 + 2 < shared_int4_0.w && o_slice < shared_int4_1.z) {
+    w2 = read_imageh(src_image2d, smp_zero, (int2)((i_slice * 4 + 2), ((W) * shared_int4_1.z + (o_slice))));
+  }
+  if (i_slice * 4 + 3 < shared_int4_0.w && o_slice < shared_int4_1.z) {
+    w3 = read_imageh(src_image2d, smp_zero, (int2)((i_slice * 4 + 3), ((W) * shared_int4_1.z + (o_slice))));
+  }
+  if (o_slice == shared_int4_1.z - 1) {
+    half4 mask = (half4)(shared_half4_0.y, shared_half4_0.z, shared_half4_0.w, shared_half4_0.x);
+    w0 *= mask;
+    w1 *= mask;
+    w2 *= mask;
+    w3 *= mask;
+  }
+  half4 r0 = w0;
+  half4 r1 = w1;
+  half4 r2 = w2;
+  half4 r3 = w3;
+  dst_tensor_buffer[linear_index * 4 + 0] = r0;
+  dst_tensor_buffer[linear_index * 4 + 1] = r1;
+  dst_tensor_buffer[linear_index * 4 + 2] = r2;
+  dst_tensor_buffer[linear_index * 4 + 3] = r3;
+}
+
+__attribute__((qcom_max_concurrent_subgroups(12)))
+__kernel void adreno_xmem_attn_pv_gemm(
+        constant half8 * weights_buffer __attribute__((sub_group_uniform)),
+        constant half8 * xmem_buffer __attribute__((max_constant_size((6144)))),
+        read_only image1d_buffer_t src_tensor_image_buffer,
+        write_only image2d_t dst_tensor_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1,
+        const int4 shared_int4_2,
+        const int4 shared_int4_3) {
+  int X = get_group_id(1) * get_local_size(0) + get_local_id(0);
+  int Y = get_group_id(2) * get_local_size(1) + get_local_id(1);
+  int Z = get_group_id(0) * get_local_size(2) + get_local_id(2);
+  if (X >= shared_int4_0.z || Y >= shared_int4_0.x) return;
+  if (Z * 8 >= shared_int4_0.y) return;
+
+  half4 r0 = (half4)(0.f);
+  half4 r1 = (half4)(0.f);
+  half4 r2 = (half4)(0.f);
+  half4 r3 = (half4)(0.f);
+  half4 r4 = (half4)(0.f);
+  half4 r5 = (half4)(0.f);
+  half4 r6 = (half4)(0.f);
+  half4 r7 = (half4)(0.f);
+  int x_coord = mad24(X, shared_int4_2.w, shared_int4_1.y);
+  int y_coord = mad24(Y, shared_int4_3.x, shared_int4_1.z);
+  int coord_x, coord_y, coord_s;
+  int f_offset = (Z * shared_int4_1.w + Y) * shared_int4_1.x * 32;
+
+  int subgroup_id = (int)((0x1F & qcom_get_physical_sub_group_id()));
+  subgroup_id = subgroup_id % 12;
+  int c_offset = mul24(subgroup_id, shared_int4_0.w);
+  __constant half16 * weights_cache = (__constant half16 *)&xmem_buffer[c_offset];
+  coord_y = Y;
+  coord_x = X;
+  int addr = (((0) * shared_int4_1.w + (coord_y)) * shared_int4_2.z + (coord_x));
+  int dz = shared_int4_2.x;
+  coord_s = 0;
+  do {
+    half4 src0 = read_imageh(src_tensor_image_buffer, addr); addr += dz;
+    coord_s++;
+    half4 src1 = read_imageh(src_tensor_image_buffer, addr); addr += dz;
+    coord_s++;
+    qcom_sub_group_constant_load8(xmem_buffer, weights_buffer, c_offset, f_offset >> 1, 32);
+    f_offset += 64;
+    qcom_sub_group_sync(QCOM_CLK_CONST_LOAD_SYNC);
+    r0 += src0.x * weights_cache[0].s0123;
+    r0 += src0.y * weights_cache[0].s4567;
+    r0 += src0.z * weights_cache[0].s89ab;
+    r0 += src0.w * weights_cache[0].scdef;
+    r1 += src0.x * weights_cache[1].s0123;
+    r1 += src0.y * weights_cache[1].s4567;
+    r1 += src0.z * weights_cache[1].s89ab;
+    r1 += src0.w * weights_cache[1].scdef;
+    r2 += src0.x * weights_cache[2].s0123;
+    r2 += src0.y * weights_cache[2].s4567;
+    r2 += src0.z * weights_cache[2].s89ab;
+    r2 += src0.w * weights_cache[2].scdef;
+    r3 += src0.x * weights_cache[3].s0123;
+    r3 += src0.y * weights_cache[3].s4567;
+    r3 += src0.z * weights_cache[3].s89ab;
+    r3 += src0.w * weights_cache[3].scdef;
+    r4 += src0.x * weights_cache[4].s0123;
+    r4 += src0.y * weights_cache[4].s4567;
+    r4 += src0.z * weights_cache[4].s89ab;
+    r4 += src0.w * weights_cache[4].scdef;
+    r5 += src0.x * weights_cache[5].s0123;
+    r5 += src0.y * weights_cache[5].s4567;
+    r5 += src0.z * weights_cache[5].s89ab;
+    r5 += src0.w * weights_cache[5].scdef;
+    r6 += src0.x * weights_cache[6].s0123;
+    r6 += src0.y * weights_cache[6].s4567;
+    r6 += src0.z * weights_cache[6].s89ab;
+    r6 += src0.w * weights_cache[6].scdef;
+    r7 += src0.x * weights_cache[7].s0123;
+    r7 += src0.y * weights_cache[7].s4567;
+    r7 += src0.z * weights_cache[7].s89ab;
+    r7 += src0.w * weights_cache[7].scdef;
+    r0 += src1.x * weights_cache[8].s0123;
+    r0 += src1.y * weights_cache[8].s4567;
+    r0 += src1.z * weights_cache[8].s89ab;
+    r0 += src1.w * weights_cache[8].scdef;
+    r1 += src1.x * weights_cache[9].s0123;
+    r1 += src1.y * weights_cache[9].s4567;
+    r1 += src1.z * weights_cache[9].s89ab;
+    r1 += src1.w * weights_cache[9].scdef;
+    r2 += src1.x * weights_cache[10].s0123;
+    r2 += src1.y * weights_cache[10].s4567;
+    r2 += src1.z * weights_cache[10].s89ab;
+    r2 += src1.w * weights_cache[10].scdef;
+    r3 += src1.x * weights_cache[11].s0123;
+    r3 += src1.y * weights_cache[11].s4567;
+    r3 += src1.z * weights_cache[11].s89ab;
+    r3 += src1.w * weights_cache[11].scdef;
+    r4 += src1.x * weights_cache[12].s0123;
+    r4 += src1.y * weights_cache[12].s4567;
+    r4 += src1.z * weights_cache[12].s89ab;
+    r4 += src1.w * weights_cache[12].scdef;
+    r5 += src1.x * weights_cache[13].s0123;
+    r5 += src1.y * weights_cache[13].s4567;
+    r5 += src1.z * weights_cache[13].s89ab;
+    r5 += src1.w * weights_cache[13].scdef;
+    r6 += src1.x * weights_cache[14].s0123;
+    r6 += src1.y * weights_cache[14].s4567;
+    r6 += src1.z * weights_cache[14].s89ab;
+    r6 += src1.w * weights_cache[14].scdef;
+    r7 += src1.x * weights_cache[15].s0123;
+    r7 += src1.y * weights_cache[15].s4567;
+    r7 += src1.z * weights_cache[15].s89ab;
+    r7 += src1.w * weights_cache[15].scdef;
+  } while (coord_s < shared_int4_2.y);
+
+  coord_s = mul24(Z, 8);
+  coord_x = X;
+  coord_y = Y;
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r0);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, ((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r1);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, ((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r2);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, ((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r3);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, ((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r4);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, ((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r5);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, ((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r6);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, ((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r7);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, ((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+}

--- a/src/ggml-opencl/kernels/transpose.cl
+++ b/src/ggml-opencl/kernels/transpose.cl
@@ -118,26 +118,48 @@ kernel void kernel_transpose_32_16(__read_only image1d_buffer_t input, __write_o
     const int j = get_global_id(1);
     const int i_2 = i<<2;
     const int j_2 = j<<2;
-    half4 temp0 = {0,0,0,0}; // initialize outputs to 0
-    half4 temp1 = {0,0,0,0};
-    half4 temp2 = {0,0,0,0};
-    half4 temp3 = {0,0,0,0};
 
-    if((j_2+0)*cols+i*4+3 < rows*cols*16){ // only load from a valid location. Otherwise keep register data as 0
-        temp0 = read_imageh(input, (j_2+0)*cols+i);
-    }
-    if((j_2+1)*cols+i*4+3 < rows*cols*16){
-        temp1 = read_imageh(input, (j_2+1)*cols+i);
-    }
-    if((j_2+2)*cols+i*4+3 < rows*cols*16){
-        temp2 = read_imageh(input, (j_2+2)*cols+i);
-    }
-    if((j_2+3)*cols+i*4+3 < rows*cols*16){
-        temp3 = read_imageh(input, (j_2+3)*cols+i);
-    }
+    float4 temp0 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp1 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp2 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp3 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
 
-    write_imageh(output, (i_2+0)*padded_rows+j, (half4)(temp0.s0, temp1.s0, temp2.s0, temp3.s0)); // no conditionals for output, includes zero padding
-    write_imageh(output, (i_2+1)*padded_rows+j, (half4)(temp0.s1, temp1.s1, temp2.s1, temp3.s1));
-    write_imageh(output, (i_2+2)*padded_rows+j, (half4)(temp0.s2, temp1.s2, temp2.s2, temp3.s2));
-    write_imageh(output, (i_2+3)*padded_rows+j, (half4)(temp0.s3, temp1.s3, temp2.s3, temp3.s3));
+    if ((j_2 + 0) < rows) temp0 = read_imagef(input, (j_2 + 0)*cols + i);
+    if ((j_2 + 1) < rows) temp1 = read_imagef(input, (j_2 + 1)*cols + i);
+    if ((j_2 + 2) < rows) temp2 = read_imagef(input, (j_2 + 2)*cols + i);
+    if ((j_2 + 3) < rows) temp3 = read_imagef(input, (j_2 + 3)*cols + i);
+
+    write_imageh(output, (i_2+0)*padded_rows+j, convert_half4((float4)(temp0.s0, temp1.s0, temp2.s0, temp3.s0)));
+    write_imageh(output, (i_2+1)*padded_rows+j, convert_half4((float4)(temp0.s1, temp1.s1, temp2.s1, temp3.s1)));
+    write_imageh(output, (i_2+2)*padded_rows+j, convert_half4((float4)(temp0.s2, temp1.s2, temp2.s2, temp3.s2)));
+    write_imageh(output, (i_2+3)*padded_rows+j, convert_half4((float4)(temp0.s3, temp1.s3, temp2.s3, temp3.s3)));
+}
+
+// 32-bit transpose with optional zero padding, stores FP32 output.
+kernel void kernel_transpose_32_32(
+    __read_only image1d_buffer_t input,
+    __write_only image1d_buffer_t output,
+    const uint rows,
+    const uint cols,
+    const uint padded_rows
+) {
+    const int i = get_global_id(0);
+    const int j = get_global_id(1);
+    const int i_2 = i << 2;
+    const int j_2 = j << 2;
+
+    float4 temp0 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp1 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp2 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 temp3 = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+
+    if ((j_2 + 0) < rows) temp0 = read_imagef(input, (j_2 + 0) * cols + i);
+    if ((j_2 + 1) < rows) temp1 = read_imagef(input, (j_2 + 1) * cols + i);
+    if ((j_2 + 2) < rows) temp2 = read_imagef(input, (j_2 + 2) * cols + i);
+    if ((j_2 + 3) < rows) temp3 = read_imagef(input, (j_2 + 3) * cols + i);
+
+    write_imagef(output, (i_2 + 0) * padded_rows + j, (float4)(temp0.s0, temp1.s0, temp2.s0, temp3.s0));
+    write_imagef(output, (i_2 + 1) * padded_rows + j, (float4)(temp0.s1, temp1.s1, temp2.s1, temp3.s1));
+    write_imagef(output, (i_2 + 2) * padded_rows + j, (float4)(temp0.s2, temp1.s2, temp2.s2, temp3.s2));
+    write_imagef(output, (i_2 + 3) * padded_rows + j, (float4)(temp0.s3, temp1.s3, temp2.s3, temp3.s3));
 }


### PR DESCRIPTION
Depends on #1561.

## Summary

This PR adds an opt-in Adreno xmem SDPA path for OpenCL diffusion attention workloads.

Scope:

- build-time gated by `GGML_OPENCL_USE_ADRENO_KERNELS`
- Adreno only
- non-causal / prefill SDPA shapes used by diffusion models
- keeps unsupported shapes on the existing OpenCL path
- keeps the existing ggml tensor layout externally

The path is intended for large diffusion attention shapes where the current OpenCL FA / nofuse routes are much slower or cannot run due to memory pressure.

## Results

Tested on Adreno 830 with OpenCL:

```text
OpenCL driver: OpenCL 3.0 QUALCOMM build: 0800.71 Compiler E031.47.18.49
```

Representative timings from the submitted xmem SDPA path:

| workload | result |
| --- | ---: |
| Flux.2 Klein 1024, 4 steps | 153.26 s sampling |
| Z-Image Turbo 1024, 1 step | 77.43 s sampling |

The large standalone attention benchmark also shows the intended speedup over the existing routes on Adreno:

| shape | xmem | existing route |
| --- | ---: | ---: |
| H=30, L=2048, D=128, non-causal | 49.852 ms | nofuse 148.097 ms |
| H=30, L=2048, D=128, causal prefill | 46.069 ms | FA 2150.036 ms / nofuse 2155.344 ms |
| H=1, L=16384, D=512, non-causal | 272.191 ms | nofuse 1084.935 ms |

## Checks

```text
git diff --check
cmake --build stable-diffusion.cpp/build-android-opencl-current-repro --target sd-cli -j 8
```
