### PR TITLE
CUDA: fix cpy transposed path corrupting non-contiguous dst

### DIFF
--- a/src/ggml-cuda/cpy.cu
+++ b/src/ggml-cuda/cpy.cu
@@ -459,7 +459,8 @@ void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, gg
 
     const bool contiguous_srcs = ggml_is_contiguous(src0) && ggml_is_contiguous(src1);
     const bool can_be_transposed = nb01 == (int64_t)ggml_element_size(src0) &&
-        src0->ne[3] == 1 && nb02 == ne00 * ne01 * (int64_t)ggml_element_size(src0);
+        src0->ne[3] == 1 && nb02 == ne00 * ne01 * (int64_t)ggml_element_size(src0) &&
+        ggml_is_contiguous(src1);
 
     size_t mc_width = 0, mc_height = 0, mc_spitch = 0, mc_dpitch = 0;
 


### PR DESCRIPTION
### Summary

`ggml_cuda_cpy`'s `can_be_transposed` gate only inspects `src0`'s layout. When the destination (`src1`) is non-contiguous - for example a strided `view_2d` slot such as a KV-cache column write - a same-type F32/F16/BF16/I32 copy still takes the transposed scalar kernel.

That kernel (`cpy_scalar_transpose`) writes the destination with a contiguous index derived from `ne00`/`ne01` and ignores the destination strides `nb10..nb13` (they are handed to `GGML_UNUSED_VARS`). The result is silent corruption of the strided destination.

### Fix

Require `ggml_is_contiguous(src1)` for the transposed fast path. Non-contiguous destinations now fall back to the general `cpy_scalar` kernel, which honors `nb10..nb13`. Contiguous destinations (the common case) are unaffected, so there is no change on the normal path.

Fixes #1497, which has the root-cause analysis and a reproduction (16 ops plus a real transformer decode). Thanks to @OriPekelman for pinpointing the exact gate and proposing this fix.

