### PR TITLE
opencl: bugfix  increase ref_count in  ggml_backend_opencl_init()

### DIFF
--- a/src/ggml-opencl/ggml-opencl.cpp
+++ b/src/ggml-opencl/ggml-opencl.cpp
@@ -7466,6 +7466,7 @@ static ggml_backend_i ggml_backend_opencl_i = {
 ggml_backend_t ggml_backend_opencl_init(void) {
     ggml_backend_dev_t dev = ggml_backend_reg_dev_get(ggml_backend_opencl_reg(), 0);
     ggml_backend_opencl_context *backend_ctx = ggml_cl_init(dev);
+    backend_ctx->ref_count++;
 
     ggml_backend_t backend = new ggml_backend {
         /* .guid    = */ ggml_backend_opencl_guid(),


### PR DESCRIPTION
This patch is important at program end in   `ggml_backend_opencl_context`'s` free()` method.

If we would not increase ref_count, we would later end with a `ref_count` of -1 and thus
some code there would not executed, e.g. flushing profiling data.  (`#ifdef GGML_OPENCL_PROFILING`)

*For changes to the core `ggml` library (including to the CMake build system), please open a PR in https://github.com/ggml-org/llama.cpp. Doing so will make your PR more visible, better tested and more likely to be reviewed.*
