### PR TITLE
Implement GGML_OP_IM2COL_3D for Metal backend

### DIFF
--- a/src/ggml-metal/ggml-metal-device.cpp
+++ b/src/ggml-metal/ggml-metal-device.cpp
@@ -1791,6 +1791,29 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_im2col(ggml_meta
     return res;
 }
 
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_im2col_3d(
+        ggml_metal_library_t lib,
+        const ggml_tensor * op) {
+
+    assert(op->op == GGML_OP_IM2COL_3D);
+
+    GGML_ASSERT(op->src[1]->type == GGML_TYPE_F32);
+    GGML_ASSERT(op->type == GGML_TYPE_F16 || op->type == GGML_TYPE_F32);
+
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_im2col_3d_%s", ggml_type_name(op->type));
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_transpose_1d(ggml_metal_library_t lib, const ggml_tensor * op) {
     assert(op->op == GGML_OP_CONV_TRANSPOSE_1D);
 

--- a/src/ggml-metal/ggml-metal-device.h
+++ b/src/ggml-metal/ggml-metal-device.h
@@ -148,6 +148,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_group_nor
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_norm              (ggml_metal_library_t lib, const struct ggml_tensor * op, int32_t n_fuse);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_rope              (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_im2col            (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_im2col_3d        (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_transpose_1d (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_transpose_2d (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_col2im_1d         (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/src/ggml-metal/ggml-metal-device.m
+++ b/src/ggml-metal/ggml-metal-device.m
@@ -1193,6 +1193,10 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
             return true;
         case GGML_OP_IM2COL:
             return ggml_is_contiguous(op->src[1]) && op->src[1]->type == GGML_TYPE_F32 && (op->type == GGML_TYPE_F16 || op->type == GGML_TYPE_F32);
+        case GGML_OP_IM2COL_3D:
+            return ggml_is_contiguous(op->src[1]) &&
+                   op->src[1]->type == GGML_TYPE_F32 &&
+                   (op->type == GGML_TYPE_F16 || op->type == GGML_TYPE_F32);
         case GGML_OP_CONV_2D:
             return ggml_is_contiguous(op->src[0]) &&
                    op->src[1]->type == GGML_TYPE_F32 &&

--- a/src/ggml-metal/ggml-metal-impl.h
+++ b/src/ggml-metal/ggml-metal-impl.h
@@ -714,6 +714,42 @@ typedef struct {
     int32_t  IW;
     int32_t  IH;
     int32_t  ID;
+    int32_t  IC;
+    int32_t  KW;
+    int32_t  KH;
+    int32_t  KD;
+    int32_t  OH;
+    int32_t  OW;
+    int32_t  OD;
+    int32_t  s0;    // stride width
+    int32_t  s1;    // stride height
+    int32_t  s2;    // stride depth
+    int32_t  p0;    // padding width
+    int32_t  p1;    // padding height
+    int32_t  p2;    // padding depth
+    int32_t  d0;    // dilation width
+    int32_t  d1;    // dilation height
+    int32_t  d2;    // dilation depth
+    int32_t  KD_KH_KW;          // precomputed: KD * KH * KW
+    int32_t  KH_KW;             // precomputed: KH * KW
+    int32_t  IC_KD_KH_KW;       // precomputed: IC * KD * KH * KW
+    int32_t  N_OD;              // precomputed: N * OD (for grid mapping)
+    int32_t  N_OD_OH;           // precomputed: N * OD * OH
+    int32_t  OD_OH;             // precomputed: OD * OH
+    int64_t  OD_OH_OW_IC_KD_KH_KW; // precomputed: output batch stride
+    int64_t  OH_OW_IC_KD_KH_KW;    // precomputed
+    int64_t  OW_IC_KD_KH_KW;       // precomputed
+    uint64_t stride_x;          // source element stride x
+    uint64_t stride_y;          // source element stride y
+    uint64_t stride_z;          // source element stride z
+    uint64_t stride_q;          // source element stride q (batch*IC)
+    uint64_t ofs0;              // source offset for batch stride (in elements)
+} ggml_metal_kargs_im2col_3d;
+
+typedef struct {
+    int32_t  IW;
+    int32_t  IH;
+    int32_t  ID;
     int32_t  OW;
     int32_t  OH;
     int32_t  OD;

--- a/src/ggml-metal/ggml-metal-ops.cpp
+++ b/src/ggml-metal/ggml-metal-ops.cpp
@@ -383,6 +383,10 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
             {
                 n_fuse = ggml_metal_op_im2col(ctx, idx);
             } break;
+        case GGML_OP_IM2COL_3D:
+            {
+                n_fuse = ggml_metal_op_im2col_3d(ctx, idx);
+            } break;
         case GGML_OP_CONV_2D:
             {
                 n_fuse = ggml_metal_op_conv_2d(ctx, idx);
@@ -3716,6 +3720,145 @@ int ggml_metal_op_im2col(ggml_metal_op_t ctx, int idx) {
 
         ggml_metal_encoder_dispatch_threadgroups(enc, quotient * CHW, OH, OW, n_threads, 1, 1);
     }
+
+    return 1;
+}
+
+int ggml_metal_op_im2col_3d(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    GGML_TENSOR_LOCALS(uint64_t, nb1, op->src[1], nb);
+    GGML_TENSOR_LOCALS(int32_t, ne,  op,         ne);
+
+    // Extract hyperparams from op_params
+    // Order: s0, s1, s2, p0, p1, p2, d0, d1, d2, IC
+    const int32_t s0 = ((const int32_t *)(op->op_params))[0];
+    const int32_t s1 = ((const int32_t *)(op->op_params))[1];
+    const int32_t s2 = ((const int32_t *)(op->op_params))[2];
+    const int32_t p0 = ((const int32_t *)(op->op_params))[3];
+    const int32_t p1 = ((const int32_t *)(op->op_params))[4];
+    const int32_t p2 = ((const int32_t *)(op->op_params))[5];
+    const int32_t d0 = ((const int32_t *)(op->op_params))[6];
+    const int32_t d1 = ((const int32_t *)(op->op_params))[7];
+    const int32_t d2 = ((const int32_t *)(op->op_params))[8];
+    const int32_t IC = ((const int32_t *)(op->op_params))[9];
+
+    // Dimensions from tensor shapes
+    // src[1] = input:  [N*IC, ID, IH, IW]
+    // src[0] = kernel: [OC*IC, KD, KH, KW]
+    // dst:             [N*OD, OH, OW, IC*KD*KH*KW]
+    const int32_t N  = op->src[1]->ne[3] / IC;
+    const int32_t ID = op->src[1]->ne[2];
+    const int32_t IH = op->src[1]->ne[1];
+    const int32_t IW = op->src[1]->ne[0];
+
+    const int32_t KD = op->src[0]->ne[2];
+    const int32_t KH = op->src[0]->ne[1];
+    const int32_t KW = op->src[0]->ne[0];
+
+    const int32_t OD = ne3 / N;
+    const int32_t OH = ne2;
+    const int32_t OW = ne1;
+
+    // Precomputed products (save GPU ALU)
+    const int32_t KD_KH_KW              = KD * KH * KW;
+    const int32_t KH_KW                 = KH * KW;
+    const int32_t IC_KD_KH_KW           = IC * KD_KH_KW;
+    const int64_t N_OD                  = (int64_t)N * OD;
+    const int32_t OD_OH                 = OD * OH;
+    const int32_t N_OD_OH               = N * OD_OH;
+    const int64_t OH_OW                 = (int64_t)OH * OW;
+    const int64_t OD_OH_OW              = (int64_t)OD * OH_OW;
+    const int64_t OD_OH_OW_IC_KD_KH_KW  = OD_OH_OW * IC_KD_KH_KW;
+    const int64_t OH_OW_IC_KD_KH_KW     = OH_OW * IC_KD_KH_KW;
+    const int64_t OW_IC_KD_KH_KW        = (int64_t)OW * IC_KD_KH_KW;
+
+    // Source byte strides → element strides
+    const size_t  es        = ggml_element_size(op->src[1]);
+    const uint64_t stride_x = nb10 / es;   // element stride along W
+    const uint64_t stride_y = nb11 / es;   // element stride along H
+    const uint64_t stride_z = nb12 / es;   // element stride along D
+    const uint64_t stride_q = nb13 / es;   // element stride along batch
+    const uint64_t ofs0     = stride_q;    // for batch loop
+
+    // Build GPU args
+    ggml_metal_kargs_im2col_3d args = {
+        /*.IW =*/ IW,
+        /*.IH =*/ IH,
+        /*.ID =*/ ID,
+        /*.IC =*/ IC,
+        /*.KW =*/ KW,
+        /*.KH =*/ KH,
+        /*.KD =*/ KD,
+        /*.OH =*/ OH,
+        /*.OW =*/ OW,
+        /*.OD =*/ OD,
+        s0, s1, s2, p0, p1, p2, d0, d1, d2,
+        /*.KD_KH_KW =*/              KD_KH_KW,
+        /*.KH_KW =*/                 KH_KW,
+        /*.IC_KD_KH_KW =*/           IC_KD_KH_KW,
+        /*.N_OD =*/                  (int32_t)N_OD,
+        /*.N_OD_OH =*/               N_OD_OH,
+        /*.OD_OH =*/                 OD_OH,
+        /*.OD_OH_OW_IC_KD_KH_KW =*/  OD_OH_OW_IC_KD_KH_KW,
+        /*.OH_OW_IC_KD_KH_KW =*/     OH_OW_IC_KD_KH_KW,
+        /*.OW_IC_KD_KH_KW =*/        OW_IC_KD_KH_KW,
+        /*.stride_x =*/ stride_x,
+        /*.stride_y =*/ stride_y,
+        /*.stride_z =*/ stride_z,
+        /*.stride_q =*/ stride_q,
+        /*.ofs0 =*/     ofs0,
+    };
+
+    // Fetch JIT pipeline
+    auto pipeline = ggml_metal_library_get_pipeline_im2col_3d(lib, op);
+
+    // Grid mapping - optimized for coalesced writes
+    // Grid:     [OW, OH, ceil(IC * N_OD / ntptg0_per_kd)]
+    // Threadgroup: [KW, KH, KD * ntptg0_per_kd]
+    //
+    // tpitg[0] = ikw (fastest varying) → writes to consecutive memory addresses
+    // tpitg[1] = ikh
+    // tpitg[2] = ikd + sub_idx * KD  (sub_idx covers IC*N_OD space)
+    //
+    // This layout ensures threads within a SIMD group write to consecutive
+    // output elements (KW innermost in memory), maximizing memory coalescing.
+    const int64_t max_threads = ggml_metal_pipeline_max_theads_per_threadgroup(pipeline);
+
+    // Calculate how many IC*N_OD sub-elements we can fit per threadgroup
+    const int64_t kernel_vol = (int64_t)KW * KH * KD;
+    const int64_t max_ic_nod_per_tg = kernel_vol < max_threads ? max_threads / kernel_vol : 1;
+
+    // Also respect max Z dimension for threadgroup (typically 512 on Apple GPUs)
+    const int64_t max_tg_z = 512;
+    const int64_t max_ic_nod_by_z = KD > 0 ? max_tg_z / KD : 1;
+
+    const int64_t IC_N_OD = (int64_t)IC * N_OD;
+    const int64_t ntptg0_per_kd = std::min({max_ic_nod_per_tg, max_ic_nod_by_z, IC_N_OD});
+
+    // Z dimension of threadgroup = KD * ntptg0_per_kd
+    const int64_t ntg_z = KD * ntptg0_per_kd;
+
+    // Number of threadgroups needed to cover all IC * N_OD positions
+    const int64_t ntg_g_z = ntptg0_per_kd > 0 ? (IC_N_OD + ntptg0_per_kd - 1) / ntptg0_per_kd : 1;
+
+    ggml_metal_encoder_set_pipeline(enc, pipeline);
+    ggml_metal_encoder_set_bytes(enc, &args, sizeof(args), 0);
+    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op->src[1]), 1);
+    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op),         2);
+
+    // Grid: [OW, OH, ntg_g_z]
+    // Threadgroup: [KW, KH, ntg_z]
+    ggml_metal_encoder_dispatch_threadgroups(enc,
+        OW,             // grid.x  (output width)
+        OH,             // grid.y  (output height)
+        ntg_g_z,        // grid.z  (IC * N_OD / ntptg0_per_kd)
+        KW,             // threadgroup.x  (kernel width - fastest for coalesced writes!)
+        KH,             // threadgroup.y  (kernel height)
+        ntg_z);         // threadgroup.z  (KD * ntptg0_per_kd)
 
     return 1;
 }

--- a/src/ggml-metal/ggml-metal-ops.h
+++ b/src/ggml-metal/ggml-metal-ops.h
@@ -74,6 +74,7 @@ int ggml_metal_op_group_norm        (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_norm              (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_rope              (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_im2col            (ggml_metal_op_t ctx, int idx);
+int ggml_metal_op_im2col_3d         (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_conv_2d           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_conv_2d_dw        (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_conv_3d           (ggml_metal_op_t ctx, int idx);

--- a/src/ggml-metal/ggml-metal.metal
+++ b/src/ggml-metal/ggml-metal.metal
@@ -11216,3 +11216,97 @@ kernel void kernel_count_equal(
 typedef decltype(kernel_count_equal<int32_t>) kernel_count_equal_t;
 
 template [[host_name("kernel_count_equal_i32")]] kernel kernel_count_equal_t kernel_count_equal<int32_t>;
+
+// IM2COL 3D: [N*IC, ID, IH, IW] => [N*OD, OH, OW, IC * KD * KH * KW]
+//
+// Optimized Metal kernel:
+//   Grid:     [OW, OH, ceil(IC * N_OD / ntptg0_per_kd)]
+//   Threadgroup: [KW, KH, KD * ntptg0_per_kd]
+//
+// Key optimizations:
+//   1. tpitg[0] = ikw (fastest varying) → coalesced writes to consecutive memory
+//   2. tpitg[1] = ikh, tpitg[2] = ikd + sub_idx*KD
+//   3. int64_t for all offsets (prevents overflow for large tensors)
+//   4. Correct padding: write 0 for ANY out-of-bounds coordinate
+//   5. No shared memory barrier needed (each thread computes its own indices)
+//   6. Bounds checks hoisted: depth/height early-exit with 0 write, not bare return
+
+typedef void (im2col_3d_t)(
+        constant ggml_metal_kargs_im2col_3d & args,
+        device const float * x,
+        device        char * dst,
+        uint3 tgpig[[threadgroup_position_in_grid]],
+        uint3  tgpg[[threadgroups_per_grid]],
+        uint3 tpitg[[thread_position_in_threadgroup]],
+        uint3   ntg[[threads_per_threadgroup]]);
+
+template <typename T>
+kernel void kernel_im2col_3d(
+        constant ggml_metal_kargs_im2col_3d & args,
+        device const float * x,
+        device        char * dst,
+        uint3 tgpig[[threadgroup_position_in_grid]],
+        uint3  tgpg[[threadgroups_per_grid]],
+        uint3 tpitg[[thread_position_in_threadgroup]],
+        uint3   ntg[[threads_per_threadgroup]]) {
+
+    // Decode kernel dimensions from threadgroup position
+    // Threadgroup layout: [KW, KH, KD * ntptg0_per_kd]
+    const int64_t ikw = (int64_t)tpitg[0];                      // kernel width  (fastest → coalesced writes)
+    const int64_t ikh = (int64_t)tpitg[1];                      // kernel height
+    const int64_t ikd = (int64_t)tpitg[2] % args.KD;           // kernel depth
+    const int64_t sub_idx = (int64_t)tpitg[2] / args.KD;       // sub-index within IC*N_OD space
+
+    // Output spatial indices from grid
+    const int64_t iow = (int64_t)tgpig[0];                      // output width
+    const int64_t ioh = (int64_t)tgpig[1];                      // output height
+
+    // Flat index across IC and N_OD dimensions
+    const int64_t flat_idx = (int64_t)tgpig[2] * (int64_t)(ntg[2] / args.KD) + sub_idx;
+
+    // Decode flat_idx → iic, in_batch, iod
+    const int64_t iic      = flat_idx / args.N_OD;
+    const int64_t i_nod    = flat_idx % args.N_OD;
+    const int64_t in_batch = i_nod / args.OD;
+    const int64_t iod      = i_nod % args.OD;
+
+    // Bounds check - skip if beyond valid range
+    if (iic >= args.IC) {
+        return;
+    }
+
+    // Compute source coordinates
+    const int64_t iiw = iow * args.s0 + ikw * args.d0 - args.p0;
+    const int64_t iih = ioh * args.s1 + ikh * args.d1 - args.p1;
+    const int64_t iid = iod * args.s2 + ikd * args.d2 - args.p2;
+
+    // Compute destination offset
+    // dst layout: [N*OD, OH, OW, IC, KD, KH, KW] (row-major: KW innermost)
+    const int64_t offset_dst =
+        ((in_batch * args.OD + iod) * args.OH * args.OW + ioh * args.OW + iow) * args.IC_KD_KH_KW
+      + iic * args.KD_KH_KW
+      + ikd * args.KH_KW
+      + ikh * args.KW
+      + ikw;
+
+    // Cast destination pointer to typed pointer
+    device T * pdst = (device T *) (dst);
+
+    // Check bounds for ALL coordinates (matching CPU behavior)
+    if (iid < 0 || iid >= args.ID || iih < 0 || iih >= args.IH || iiw < 0 || iiw >= args.IW) {
+        pdst[offset_dst] = (T)0.0f;
+    } else {
+        // Compute source offset (element stride based)
+        // Cast strides to int64_t (they are uint64_t in struct but always fit)
+        const int64_t offset_src =
+            (in_batch * args.IC + iic) * (int64_t)args.stride_q
+          + iid * (int64_t)args.stride_z
+          + iih * (int64_t)args.stride_y
+          + iiw * (int64_t)args.stride_x;
+
+        pdst[offset_dst] = (T)x[offset_src];
+    }
+}
+
+template [[host_name("kernel_im2col_3d_f32")]] kernel im2col_3d_t kernel_im2col_3d<float>;
+template [[host_name("kernel_im2col_3d_f16")]] kernel im2col_3d_t kernel_im2col_3d<half>;


### PR DESCRIPTION
Add 3D im2col operation support in Apple Metal backend:

- Add `ggml_metal_kargs_im2col_3d` struct with 3D kernel dimensions and precomputed products for GPU efficiency
- Add `ggml_metal_library_get_pipeline_im2col_3d()` for JIT pipeline
- Add `ggml_metal_op_im2col_3d()` with optimized grid/threadgroup dispatch (coalesced writes with KW-innermost layout)
- Add `kernel_im2col_3d` Metal kernel (f32/f16) with int64 offsets to prevent overflow on large tensors
- Register GGML_OP_IM2COL_3D in supports_op and op encoder

The kernel maps input [N*IC, ID, IH, IW] to output [N*OD, OH, OW, IC*KD*KH*KW] using configurable strides, paddings, and dilations across all 3 spatial dimensions.

## Before this PR

[log2.log](https://github.com/user-attachments/files/30433824/log2.log)

## This PR

[log.log](https://github.com/user-attachments/files/30433832/log.log)

