### PR TITLE
Handle F32 x F16 src1 in CUDA binary broadcast ops

### DIFF
--- a/src/ggml-cuda/binbcast.cu
+++ b/src/ggml-cuda/binbcast.cu
@@ -415,8 +415,12 @@ static void ggml_cuda_op_bin_bcast(
 
     GGML_ASSERT(src1->type == GGML_TYPE_F32 || src1->type == GGML_TYPE_F16);
 
-    if (src0->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32) {
+    if (src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32) {
         op()(src0, src1, dst, (const float *)src0_dd, (const float *)src1_dd, (float *)dst_dd, stream);
+    } else if (src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F16 && dst->type == GGML_TYPE_F32) {
+        // F32 src0 x F16 src1: read src1 as `half` with half-strides so the
+        // f16 tensor stays in place (no upcast copy needed).
+        op()(src0, src1, dst, (const float *) src0_dd, (const half *)src1_dd, (float *)dst_dd, stream);
     } else if (src0->type == GGML_TYPE_F16 && src1->type == GGML_TYPE_F16 && dst->type == GGML_TYPE_F16) {
         op()(src0, src1, dst, (const half *) src0_dd, (const half *)src1_dd, (half *) dst_dd, stream);
     } else if (src0->type == GGML_TYPE_F16 && src1->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F16) {
@@ -457,9 +461,13 @@ static void ggml_cuda_op_fused_binbcast_impl(ggml_backend_cuda_context & ctx, gg
     const ggml_tensor * src0 = dst->src[0];
     const ggml_tensor * src1 = dst->src[1];
 
-    if (src0->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32) {
+    if (src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32) {
         launch_bin_bcast_pack<op, float, float, float>(src0, src1, dst,
             (const float *) src0->data, (const float *) src1->data, (float *) dst->data,
+            stream, std::make_index_sequence<n_fuse>{});
+    } else if (src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F16 && dst->type == GGML_TYPE_F32) {
+        launch_bin_bcast_pack<op, float, half, float>(src0, src1, dst,
+            (const float *) src0->data, (const half *) src1->data, (float *) dst->data,
             stream, std::make_index_sequence<n_fuse>{});
     } else if (src0->type == GGML_TYPE_F16 && src1->type == GGML_TYPE_F16 && dst->type == GGML_TYPE_F16) {
         launch_bin_bcast_pack<op, half, half, half>(src0, src1, dst,


### PR DESCRIPTION
## Problem

`ggml_cuda_op_bin_bcast` and `ggml_cuda_op_fused_binbcast_impl` dispatch on the
types of `src0` and `dst` only. The first branch matches any `F32 src0 / F32 dst`
pair and instantiates `src1_t = float` — **without verifying `src1`'s type**.

When `src1` is actually `F16` (for example an F16 per-channel scale or
LayerScale weight broadcast over F32 activations), the kernel reads the tensor
with float strides. `launch_bin_bcast_pack` detects the mismatch via the
`nb10 % sizeof(src1_t) == 0` alignment assert and aborts:

```
binbcast.cu:293: GGML_ASSERT(nb10 % sizeof(src1_t) == 0) failed
```

The `F16 src0 / F32 src1` mixed case has always been handled; only the
`F32 src0 / F16 src1` combination was missing. The same pattern exists in both
the regular and the fused dispatcher.

## Change

- Require `src1 == F32` in the pure F32/F32 branch (it previously matched any
  `src1`).
- Add the missing `F32 src0 / F16 src1 / F32 dst` branch to both the regular
  and the fused dispatchers, reading `src1` as `half` so the F16 tensor stays
  in place (no upcast copy needed).

## Testing

- Reproduced the assert with an F32×F16 broadcast graph on an Ampere GPU
  (sm_86, CUDA 12.6); the graph now computes correctly.
- Existing mixed-type paths (F32/F32, F16/F16, F16/F32) are unchanged —
  the fix only adds a branch and tightens an existing condition.

## Notes

- The patch was validated against the ggml version pinned by the
  `CrispStrobe/ggml` fork (`4d9a5c3d`, v0.10.2-462). The same bug exists in
  upstream `ggml-org/ggml` master, so the fix should apply cleanly to both.
