### PR TITLE
ci : extract build job into separate release workflow

### DIFF
--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -11,58 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        libraries: [shared, static]
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-    - name: Clone
-      uses: actions/checkout@v6
-
-    - name: Dependencies for Ubuntu
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update
-        sudo apt-get install llvm
-
-    - name: Add msbuild to PATH
-      if: matrix.os == 'windows-latest'
-      uses: microsoft/setup-msbuild@v2
-
-    - name: Create Build Environment
-      run: mkdir build
-
-    - name: Configure CMake
-      working-directory: ./build
-      run: cmake ..
-        ${{ contains(matrix.os, 'windows') && '-A x64' || '-G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++' }}
-        ${{ matrix.libraries == 'static' && '-DBUILD_SHARED_LIBS=OFF' || '-DBUILD_SHARED_LIBS=ON' }}
-        -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/installed
-        -DGGML_METAL=OFF
-
-    - name: Build
-      working-directory: ./build
-      run: cmake --build . ${{ contains(matrix.os, 'windows') && '--config Release' || '' }}
-
-    - name: Test
-      working-directory: ./build
-      run: ctest --verbose --timeout 900 ${{ contains(matrix.os, 'windows') && '--build-config Release' || '' }}
-
-    - name: Install
-      working-directory: ./build
-      run: cmake --build . --target install ${{ contains(matrix.os, 'windows') && '--config Release' || '' }}
-
-    - name: Test CMake config
-      run: |
-        mkdir test-cmake
-        cmake -S examples/test-cmake -B test-cmake -DCMAKE_PREFIX_PATH=${{ github.workspace }}/installed ${{ contains(matrix.os, 'windows') && '-A x64' || '-G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++' }}
-        cmake --build test-cmake ${{ contains(matrix.os, 'windows') && '--config Release' || '' }}
-
-# TODO: simplify the following workflows using a matrix
+  # TODO: simplify the following workflows using a matrix
   x64-cpu-low-perf:
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: release
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        libraries: [shared, static]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Clone
+      uses: actions/checkout@v6
+
+    - name: Dependencies for Ubuntu
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install llvm
+
+    - name: Add msbuild to PATH
+      if: matrix.os == 'windows-latest'
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Create Build Environment
+      run: mkdir build
+
+    - name: Configure CMake
+      working-directory: ./build
+      run: cmake ..
+        ${{ contains(matrix.os, 'windows') && '-A x64' || '-G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++' }}
+        ${{ matrix.libraries == 'static' && '-DBUILD_SHARED_LIBS=OFF' || '-DBUILD_SHARED_LIBS=ON' }}
+        -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/installed
+        -DGGML_METAL=OFF
+
+    - name: Build
+      working-directory: ./build
+      run: cmake --build . ${{ contains(matrix.os, 'windows') && '--config Release' || '' }}
+
+    - name: Test
+      working-directory: ./build
+      run: ctest --verbose --timeout 900 ${{ contains(matrix.os, 'windows') && '--build-config Release' || '' }}
+
+    - name: Install
+      working-directory: ./build
+      run: cmake --build . --target install ${{ contains(matrix.os, 'windows') && '--config Release' || '' }}
+
+    - name: Test CMake config
+      run: |
+        mkdir test-cmake
+        cmake -S examples/test-cmake -B test-cmake -DCMAKE_PREFIX_PATH=${{ github.workspace }}/installed ${{ contains(matrix.os, 'windows') && '-A x64' || '-G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++' }}
+        cmake --build test-cmake ${{ contains(matrix.os, 'windows') && '--config Release' || '' }}

--- a/scripts/make-release-checks.sh
+++ b/scripts/make-release-checks.sh
@@ -71,23 +71,23 @@ if git ls-remote --tags origin "${VERSION}" | grep -q "${VERSION}"; then
 fi
 echo "Tag ${VERSION} does not exist on remote - OK"
 
-echo "Checking build-cpu.yml status for commit ${SHA}..."
+echo "Checking release.yml status for commit ${SHA}..."
 if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
     echo "Warning: GITHUB_REPOSITORY not set - skipping CI check (local run)"
 else
-    RUNS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build-cpu.yml/runs?per_page=100" \
+    RUNS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/release.yml/runs?per_page=100" \
         --jq "[.workflow_runs[] | select(.head_sha == \"${SHA}\" and .conclusion == \"success\")] | length")
     if [[ "$RUNS" -eq 0 ]]; then
         if [[ "$DRY_RUN" == "true" ]]; then
-            echo "Warning: no successful build-cpu.yml run found for HEAD (${SHA}) (dry run, continuing)."
+            echo "Warning: no successful release.yml run found for HEAD (${SHA}) (dry run, continuing)."
             CHECKS_PASSED=false
         else
-            echo "Error: no successful build-cpu.yml run found for HEAD (${SHA})"
-            echo "The build-cpu workflow must complete successfully before making a release."
+            echo "Error: no successful release.yml run found for HEAD (${SHA})"
+            echo "The release workflow must complete successfully before making a release."
             exit 1
         fi
     else
-        echo "Found successful build-cpu.yml run for HEAD."
+        echo "Found successful release.yml run for HEAD."
     fi
 fi
 


### PR DESCRIPTION
Move the build job out of build-cpu.yml into a dedicated release.yml
workflow (same triggers and concurrency as build-cpu), leaving only the
perf test jobs in build-cpu.

Release gating in scripts/make-release-checks.sh now requires a
successful release.yml run for the release commit instead of a
successful build-cpu.yml run.

AI usage: YES. pi:llama.cpp/Qwen3.8-27B