### PR TITLE
ci : run builds only on source and build file changes

### DIFF
--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -3,8 +3,30 @@ name: build-cpu
 on:
   push:
     branches: [ master ]
+    paths:
+      - '.github/workflows/build-cpu.yml'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'ci/**'
+      - 'examples/**'
+      - 'ggml.pc.in'
+      - 'include/**'
+      - 'requirements.txt'
+      - 'src/**'
+      - 'tests/**'
   pull_request:
     branches: [ master ]
+    paths:
+      - '.github/workflows/build-cpu.yml'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'ci/**'
+      - 'examples/**'
+      - 'ggml.pc.in'
+      - 'include/**'
+      - 'requirements.txt'
+      - 'src/**'
+      - 'tests/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -3,8 +3,30 @@ name: build-self-hosted
 on:
   push:
     branches: [ master ]
+    paths:
+      - '.github/workflows/build-self-hosted.yml'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'ci/**'
+      - 'examples/**'
+      - 'ggml.pc.in'
+      - 'include/**'
+      - 'requirements.txt'
+      - 'src/**'
+      - 'tests/**'
   pull_request:
     branches: [ master ]
+    paths:
+      - '.github/workflows/build-self-hosted.yml'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'ci/**'
+      - 'examples/**'
+      - 'ggml.pc.in'
+      - 'include/**'
+      - 'requirements.txt'
+      - 'src/**'
+      - 'tests/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,30 @@ name: release
 on:
   push:
     branches: [ master ]
+    paths:
+      - '.github/workflows/release.yml'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'ci/**'
+      - 'examples/**'
+      - 'ggml.pc.in'
+      - 'include/**'
+      - 'requirements.txt'
+      - 'src/**'
+      - 'tests/**'
   pull_request:
     branches: [ master ]
+    paths:
+      - '.github/workflows/release.yml'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'ci/**'
+      - 'examples/**'
+      - 'ggml.pc.in'
+      - 'include/**'
+      - 'requirements.txt'
+      - 'src/**'
+      - 'tests/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}


### PR DESCRIPTION
Currently, the `build-cpu`, `build-self-hosted` and `release` workflows run on
any push/PR to `master`, including changes that don't affect the build (e.g. README).

This PR adds `paths` filters to both `push` and `pull_request` triggers so they
only run when source or build files change:

- `src/**`, `include/**`, `tests/**`, `examples/**` — source code
- `CMakeLists.txt`, `cmake/**` — build system
- `ci/**`, `requirements.txt`, `ggml.pc.in` — CI build script and its deps
- the workflow file itself — so workflow changes get re-tested

`make-release` is unchanged (manual `workflow_dispatch` only).

Note 1: directory-based filters are used instead of the extension-based ones in
llama.cpp (`**/*.cu`, ...). I verified with picomatch that the `**/.cmake`
pattern there does not match `cmake/*.cmake` files (only a file literally
named `.cmake`), which would miss all 4 cmake modules in this repo.

Note 2: CI-only change to ggml's own workflows, hence opened here rather than
in llama.cpp (see PR template note).

## AI usage

YES. pi:llama.cpp/Qwen3.8-27B
