### PR TITLE
Fix builds on s390x

### DIFF
--- a/src/ggml-cpu/CMakeLists.txt
+++ b/src/ggml-cpu/CMakeLists.txt
@@ -673,6 +673,10 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
     target_compile_options(${GGML_CPU_NAME} PRIVATE ${ARCH_FLAGS})
     target_compile_definitions(${GGML_CPU_NAME} PRIVATE ${ARCH_DEFINITIONS})
 
+    if (GGML_LTO AND NOT MSVC)
+        target_link_options(${GGML_CPU_NAME} PRIVATE ${ARCH_FLAGS})
+    endif()
+
     if (EMSCRIPTEN)
         set_target_properties(${GGML_CPU_NAME} PROPERTIES COMPILE_FLAGS "-msimd128")
     endif()


### PR DESCRIPTION
The CPU backend on s390x (z15/z16) is compiled with -march=z15 / -march=z16 -mvx, but these -march flags aren't passed to the linker, so it uses the baseline -march=z196, which fails to build with:

    lto1: error: hardware vector support not available on z196

Pass these flags to the linker when doing LTO. The same fix also affects riscv64 / -march=rv64gc_v.

Fixes: https://github.com/ggml-org/llama.cpp/pull/19341
